### PR TITLE
Normalize document to always include a trailing block

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -51,8 +51,8 @@
     "not op_mini all"
   ],
   "devDependencies": {
-    "babel-eslint": "^10.0.1",
     "@babel/register": "^7.0.0",
+    "babel-eslint": "^10.0.1",
     "collecticons-processor": "^4.0.1",
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.9.1",

--- a/app/src/components/FreeEditor.js
+++ b/app/src/components/FreeEditor.js
@@ -6,6 +6,7 @@ import SoftBreak from 'slate-soft-break';
 import PluginDeepTable from 'slate-deep-table';
 import styled from 'styled-components/macro';
 import EquationEditor from './EquationEditor';
+import TrailingBlock from '../slate-plugins/TrailingBlock';
 import {
   ToolbarAction,
   ToolbarIcon,
@@ -30,8 +31,9 @@ const EditorContainer = styled.div`
 `;
 
 const plugins = [
+  TrailingBlock(),
   SoftBreak(),
-  PluginDeepTable()
+  PluginDeepTable(),
 ];
 
 export class FreeEditor extends React.Component {
@@ -136,8 +138,6 @@ export class FreeEditor extends React.Component {
   }
 
   insertTable() {
-    this.insertParagraph();
-    this.editor.moveBackward(1);
     this.editor.insertTable();
   }
 

--- a/app/src/slate-plugins/TrailingBlock.js
+++ b/app/src/slate-plugins/TrailingBlock.js
@@ -1,0 +1,30 @@
+import { Block, Text } from 'slate';
+
+// Make sure the document always ends in an empty paragraph block,
+// except when the last node in a document is already a paragraph block.
+// Simplified and modified from below, a plugin which doesn't seem to work anymore.
+// https://github.com/GitbookIO/slate-trailing-block/blob/master/lib/index.js
+export default function TrailingBlock() {
+  return {
+    normalizeNode: (node) => {
+      if (node.object !== 'document') {
+        return undefined;
+      }
+
+      const lastNode = node.nodes.last();
+
+      // Don't insert another paragraph if the last node in the document
+      // is already a paragraph.
+      if (lastNode && lastNode.type === 'paragraph') {
+        return undefined;
+      }
+
+      const lastIndex = node.nodes.count();
+      const block = Block.create({
+        type: 'paragraph',
+        nodes: [Text.create()]
+      });
+      return change => change.insertNodeByKey(node.key, lastIndex, block);
+    }
+  };
+}


### PR DESCRIPTION
@sharkinsspatial this includes a plugin to add a trailing paragraph node to the end of the document, whenever the document doesn't already end in a paragraph node.

This eliminates the need to create an empty paragraph, then step back, when inserting image or table nodes.

The big benefit here is, if your document ends in a table, you can backspace into the table without removing the last paragraph node (meaning you can now add more content below the table).

See this for illustration:

![trailing-block-demo](https://user-images.githubusercontent.com/1590802/55593493-f12e6480-56f0-11e9-97ac-a52b95b194fb.gif)
