### PR TITLE
Fix typo in style.

### DIFF
--- a/app/src/components/FreeEditor.js
+++ b/app/src/components/FreeEditor.js
@@ -23,7 +23,7 @@ const paragraph = 'paragraph';
 const table = 'table';
 
 const EditorContainer = styled.div`
-  background-color: ${themeVal('color.surface')}
+  background-color: ${themeVal('color.surface')};
   border: 1px solid ${themeVal('color.gray')};
   border-bottom-left-radius: ${multiply(themeVal('layout.space'), 0.25)};
   border-bottom-right-radius: ${multiply(themeVal('layout.space'), 0.25)};


### PR DESCRIPTION
@dereklieu I inadvertently introduced a typo to the `FreeEditor` style in the last PR.  We should apply this one before we merge your table tool work.