### PR TITLE
Add navigation to step buttons

### DIFF
--- a/app/src/components/common/EditPage.js
+++ b/app/src/components/common/EditPage.js
@@ -171,13 +171,14 @@ const EditPage = (props) => {
                     variation="achromic-plain"
                     title="View previous step"
                     onClick={() => items[step - 2].link && props.push(items[step - 2].link)}
-                  // { step == 1 ? disabled : '' }
+                    disabled={(step === 1)}
                   > Prev
                   </PrevButton>
                   <NextButton
                     variation="achromic-plain"
                     title="View next step"
                     onClick={() => items[step].link && props.push(items[step].link)}
+                    disabled={(step === 7)}
                   > Next
                   </NextButton>
                 </InpageToolbar>


### PR DESCRIPTION
Done: Navigation between pages using Next and Prev buttons
To Do: Disable `Prev` when on the first step, and `Next` when on the last one