### PR TITLE
Remove placeholder fields and use first contact as the author

### DIFF
--- a/app/src/components/AtbdList.js
+++ b/app/src/components/AtbdList.js
@@ -144,10 +144,12 @@ const AtbdList = (props) => {
   } = props;
 
   const atbdElements = atbds.map((atbd) => {
-    const { atbd_id, title, atbd_versions, contacts } = atbd;
-    let contact = ''
-    if (contacts[0] !== undefined){
-      contact = contacts[0].first_name + ' ' + contacts[0].last_name
+    const {
+      atbd_id, title, atbd_versions, contacts
+    } = atbd;
+    let contact = '';
+    if (contacts[0] !== undefined) {
+      contact = `${contacts[0].first_name} ${contacts[0].last_name}`;
     }
     const { status } = atbd_versions[0];
     return (


### PR DESCRIPTION
New layout:

<img width="1252" alt="image" src="https://user-images.githubusercontent.com/6155420/58890735-32270300-86b9-11e9-894a-d2b227ebfc4d.png">


@ricardomestre Do you have time to:
1) Expand the size of the author field so that we use the full width?
2) Enable the hover-over preview for long names? (I think this was in one of the wireframes)