### PR TITLE
Remove styling around table header

### DIFF
--- a/ecs/tex/serialize.py
+++ b/ecs/tex/serialize.py
@@ -34,7 +34,7 @@ def processTable(nodeRows):
     columnNames = tableList.pop(0)
     pd.set_option('display.max_colwidth', 1000)
     df = pd.DataFrame(tableList, columns=columnNames)
-    latexTable = df.to_latex(index=False, escape=False)
+    latexTable = df.to_latex(index=False, escape=False, header=False)
     return latexTable
 
 def addMarkup(text, marks):


### PR DESCRIPTION
Closes #211 

Note: this will need testing, but I think this should handle removing the header styling in the LaTeX code

To test the LaTeX code locally, run the following from within the `ecs/tex` folder:

```python serialize.py replace-this-name.json``` 

(see this [line](https://github.com/developmentseed/nasa-apt/blob/develop/ecs/tex/entrypoint.sh#L17) for reference)

Then run this [line](https://github.com/developmentseed/nasa-apt/blob/develop/ecs/pdf/entrypoint.sh#L13), which locally can look something like this:
```
export TEXname=replace-this-name.tex
pdflatex --shell-escape "\def\convertType{PDF}\input{$TEXname}"
```

If you don't want to download pdflatex and the python requirements, you can run the `tex` and `pdf` docker images locally by slightly modifying these [instructions](https://github.com/developmentseed/nasa-apt/tree/develop/ecs) and use them to execute the above commands.