### PR TITLE
add search for every text anything

### DIFF
--- a/db/deploy/searcheverything.sql
+++ b/db/deploy/searcheverything.sql
@@ -1,0 +1,55 @@
+-- Deploy nasa-apt:searcheverything to pg
+-- requires: textsearchAlias
+BEGIN;
+SET SEARCH_PATH TO apt, public;
+
+DROP VIEW IF EXISTS atbd_search CASCADE;
+CREATE OR REPLACE VIEW atbd_search AS
+SELECT
+atbds.*,
+json_agg(row_to_json(atbd_versions)) as atbd_versions,
+json_agg(row_to_json(contacts)) as contacts,
+json_agg(row_to_json(contact_groups)) as contact_groups,
+json_agg(row_to_json(citations)) as citations,
+json_agg(row_to_json(algorithm_input_variables)) as algorithm_input_variables,
+json_agg(row_to_json(algorithm_output_variables)) as algorithm_output_variables,
+json_agg(row_to_json(publication_references)) as publication_references,
+json_agg(row_to_json(data_access_input_data)) as data_access_input_data,
+json_agg(row_to_json(data_access_output_data)) as data_access_output_data,
+json_agg(row_to_json(data_access_related_urls)) as data_access_related_urls,
+to_tsvector(coalesce(atbds.title,'')) ||
+json_to_tsvector(
+    json_build_array(
+        json_agg(row_to_json(atbd_versions)),
+        json_agg(row_to_json(contacts)),
+        json_agg(row_to_json(contact_groups)),
+        json_agg(row_to_json(citations)),
+        json_agg(row_to_json(algorithm_input_variables)),
+        json_agg(row_to_json(algorithm_output_variables)),
+        json_agg(row_to_json(publication_references)),
+        json_agg(row_to_json(data_access_input_data)),
+        json_agg(row_to_json(data_access_output_data)),
+        json_agg(row_to_json(data_access_related_urls))
+    ),
+    '["string"]'
+) as search
+FROM
+atbds
+LEFT JOIN atbd_versions USING (atbd_id)
+LEFT JOIN atbd_contacts USING
+(atbd_id)
+LEFT JOIN contacts USING (contact_id)
+LEFT JOIN atbd_contact_groups USING (atbd_id)
+LEFT JOIN contact_groups USING (contact_group_id)
+LEFT JOIN citations USING (atbd_id, atbd_version)
+LEFT JOIN algorithm_input_variables USING (atbd_id, atbd_version)
+LEFT JOIN algorithm_output_variables USING (atbd_id, atbd_version)
+LEFT JOIN algorithm_implementations USING (atbd_id, atbd_version)
+LEFT JOIN publication_references USING (atbd_id, atbd_version)
+LEFT JOIN data_access_input_data USING (atbd_id, atbd_version)
+LEFT JOIN data_access_output_data USING (atbd_id, atbd_version)
+LEFT JOIN data_access_related_urls USING (atbd_id, atbd_version)
+GROUP BY atbd_id, atbd_version, status;
+
+
+COMMIT;

--- a/db/revert/searcheverything.sql
+++ b/db/revert/searcheverything.sql
@@ -1,0 +1,7 @@
+-- Revert nasa-apt:searcheverything from pg
+
+BEGIN;
+
+-- XXX Add DDLs here.
+
+COMMIT;

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -13,3 +13,4 @@ copyATBD [tables] 2019-10-18T14:14:13Z Alyssa Harris <alyssaharris@Alyssas-MacBo
 atbdAlias [tables] 2020-05-07T14:34:43Z Daniel da Silva <daniel@hystericalhamster> # Add alias field to atbd
 copyATBDAlias [copyATBD] 2020-05-08T15:56:26Z Daniel da Silva <daniel@hystericalhamster> # Creates a unique alias when copying atbd
 textsearchAlias [textsearch] 2020-05-08T15:57:18Z Daniel da Silva <daniel@hystericalhamster> # Includes the atbs alias when searching
+searcheverything [textsearchAlias] 2020-07-01T20:43:28Z David Bitner <bitner@bitner-devseed> # add search over every json/text field

--- a/db/verify/searcheverything.sql
+++ b/db/verify/searcheverything.sql
@@ -1,0 +1,7 @@
+-- Verify nasa-apt:searcheverything on pg
+
+BEGIN;
+
+-- XXX Add verifications here.
+
+ROLLBACK;


### PR DESCRIPTION
This adds a view that aggregates everything for each atbd_version and returns it as nested json.

Additionally it adds a "search" column that is a ts_vector to use with full text search operators in postgresql. This field contains a lookup of all text fields anywhere in related tables to the atbd.

The view can be accessed from postgrest like a normal table at:
http://localhost:3000/atbd_search

You can use the four different modes of Full Text Search as documented here:
http://postgrest.org/en/v7.0.0/api.html#operators

So to use the plainto_tsearch which is what you have been using in the existing search function, you would use
http://localhost:3000/atbd_search?search=plfts.input

Additional exact filters can be applied as normal following the Postgrest docs. Every column should be available in the returned json. You will probably want to make sure to use either the limit parameters or headers as well. You can limit what information is returned using the select= parameter, so if you just wanted to get the ids for things that matched a search, you could use:
http://localhost:3000/atbd_search?select=atbd_id,atbd_versions-%3E0-%3Eatbd_version&search=plfts.input
