### PR TITLE
Add placement param to figures

### DIFF
--- a/pdf/app/latex/ATBD.tex
+++ b/pdf/app/latex/ATBD.tex
@@ -22,6 +22,7 @@ Some other text
 \usepackage{url}
 \usepackage{booktabs}
 \usepackage{graphicx}
+\usepackage{float}
 \hypersetup{
     colorlinks=true, %set true if you want colored links
     linktoc=all,     %set to all if you want both sections and subsections linked

--- a/pdf/app/latex/serialize.py
+++ b/pdf/app/latex/serialize.py
@@ -117,7 +117,7 @@ def saveImage(imgUrl, img):
 def wrapImage(img, cap=''):
     if cap:
         cap = f'\\caption{{{cap}}}'
-    wrapper = f''' \\begin{{figure}}[h]
+    wrapper = f''' \\begin{{figure}}[H]
         \\includegraphics[width=\\maxwidth{{\\linewidth}}]{{\\{img}}}
         {cap}
         \\end{{figure}}


### PR DESCRIPTION
LaTeX floats objects like images because they should not be broken over pages. This means that by default it will decide where to put an image in the layout. I have added the `h` parameter to the figures in the latex markup which indicates `place approximately here` see [docs](https://www.overleaf.com/learn/latex/Positioning_of_Figures). This should address #257, this is somewhat tough to test because of image upload problems.

I think this might be sufficient? TeX often requires tends to require additional commands inserted into the template to tune a layout to what the author wants, so it is hard to allow complete control from the front end without creating a 1:1 correspondence with LaTeX commands. 