### PR TITLE
Update citation style to more closely match APA style citations

### DIFF
--- a/fastapi/app/latex/ATBD_JOURNAL.tex
+++ b/fastapi/app/latex/ATBD_JOURNAL.tex
@@ -28,6 +28,9 @@ Some other text
 \usepackage{amsmath}
 \usepackage{array}
 
+\usepackage{natbib}
+\setcitestyle{authoryear}
+
 
 \usepackage{setspace}
 \doublespacing
@@ -106,7 +109,7 @@ Some other text
 \section{Contacts}
 \Contacts
 
-\bibliographystyle{abbrv}
+\bibliographystyle{abbrvnat}
 \bibliography{main}
 
 \end{document}

--- a/fastapi/app/latex/serialize.py
+++ b/fastapi/app/latex/serialize.py
@@ -131,7 +131,7 @@ def processText(nodes):
         elif node["object"] == "inline" and node["type"] == "reference":
             try:
                 refID = refIDs[node["data"]["id"]]
-                to_return += f"\\cite{{{refID}}}"
+                to_return += f"\\citep{{{refID}}}"
             except KeyError:
                 to_return += ""
     return to_return
@@ -414,6 +414,8 @@ def processReferences(refs):
             this_ref += "NUMBER" + '="{}", \n'.format(ref["issue"])
         if ref["year"] is not None:
             this_ref += "YEAR" + '="{}", \n'.format(ref["year"])
+        if ref["doi"] is not None:
+            this_ref += "DOI" + '="{}", \n'.format(ref["doi"])
         bibtexRef = f"@ARTICLE{{{identifier},{this_ref}}}"
         references.append(bibtexRef)
         refIDs[ref["publication_reference_id"]] = identifier
@@ -463,6 +465,7 @@ class ATBD:
     def texVariables(self):
         myJson = json.loads(open(self.filepath).read())
         processReferences(myJson.pop("publication_references"))
+        print("References: ", references)
         commands = processATBD(myJson.pop("atbd"))
         if debug:
             for item, value in myJson.items():


### PR DESCRIPTION
I updated the references to more closely match APA style, as described by [this document](https://docs.google.com/document/d/1lQ07lFzkNpSK8qYiTcs5d3mfzhNH1qyoah0pjw682jQ/edit):

**Reference format:** Follows APA, 6th edition.
**In-text citations:**
- [x] Need to replace brackets with parentheses, 
![image](https://user-images.githubusercontent.com/11858457/107421411-eeb8a500-6ae7-11eb-81f2-f71da7dd0b16.png)

- [ ] and replace “and” with “&”
[Bibtex separates the list of authors on the keyword "and"](https://en.wikibooks.org/wiki/LaTeX/Bibliography_Management#Authors) . Replacing "and" with "&" would make Bibtex consider that there was only one author (with "&" in their name)

- [ ] Make sure parenthetical citations of two or more papers are separated by “;”. Example, (Zhang 2001; Sims 2020).  Did not see an example in the ATBD to check for this.
While this is handled in the backend: ![image](https://user-images.githubusercontent.com/11858457/107421705-4a832e00-6ae8-11eb-8cfc-fd63dd3efda3.png) it requires a frontend modification to insert be able to insert 2 references at the same position. Currently the front end treats two consecutive references as two separate elements, which looks like when the paper is generated: ![image](https://user-images.githubusercontent.com/11858457/107422433-02b0d680-6ae9-11eb-9ebb-810671b0970c.png)

- [ ] If two or more references from the same year, use a, b, c, etc.  Example: (Tuller et al. 2016a; Tuller et al. 2016b)
I was unable to even find an example of this within any of the Bibtext documentation. 

- [x] Remove numbers for each reference indicating when they appear in the text. [1], [2], [3], etc.
![image](https://user-images.githubusercontent.com/11858457/107422581-3429a200-6ae9-11eb-9829-aa3c940049e5.png)

**Reference list:** 
- [x] Place references in alphabetical order based on the first author’s last name.
![image](https://user-images.githubusercontent.com/11858457/107422655-4b688f80-6ae9-11eb-8d7b-ba268e0a5eb5.png)

- [x] Remove numbers indicating when the reference appears in the text.
See above image

- [x] DOIs are required for AGU journal articles and should be included for non-AGU publications.
See above image

- [x] Spell out journal names; no abbreviations
See above image

- [ ] No period following URL or DOI 
I was unable to find an option for this. 

For full samples of the files the screenshots came from: 
Sample journal with a single reference: 
[sample_journal_atbd.pdf](https://github.com/developmentseed/nasa-apt/files/5953998/sample_journal_atbd.pdf)

Sample journal with multiple references as they are currently being handled (ie: 2 refs at the same position are considered as 2 separate references)
[sample_journal_atbd_separate_refs.pdf](https://github.com/developmentseed/nasa-apt/files/5953996/sample_journal_atbd_separate_refs.pdf)

Sample journal with combined references (requires front end functionality to combine references anchors when inserting a second reference at the same position). 
[sample_journal_atbd_combined_refs.pdf](https://github.com/developmentseed/nasa-apt/files/5953997/sample_journal_atbd_combined_refs.pdf)


