### PR TITLE
Changes to reference schema

### DIFF
--- a/app/schemas/document.py
+++ b/app/schemas/document.py
@@ -81,8 +81,8 @@ class PublicationReference(BaseModel):
     publication_place: Optional[str]
     publisher: Optional[str]
     pages: Optional[str]
-    isbn: Optional[int]
-    year: Optional[int]
+    isbn: Optional[str]
+    year: Optional[str]
 
 
 class DataAccessUrl(BaseModel):

--- a/db/testDataLocal.sql
+++ b/db/testDataLocal.sql
@@ -438,8 +438,8 @@ VALUES
       "publication_place": "Boston",
       "publisher": "PenguinBooks",
       "pages": "189-198",
-      "isbn": 123456789,
-      "year": 1995
+      "isbn": "123456789",
+      "year": "1995"
     }
   ]
 }', '{
@@ -867,8 +867,8 @@ VALUES
       "publication_place": "Boston",
       "publisher": "PenguinBooks",
       "pages": "189-198",
-      "isbn": 123456789,
-      "year": 1995
+      "isbn": "123456789",
+      "year": "1995"
     }
   ]
 }', '{


### PR DESCRIPTION
The reference `id` must be a string because we're using 8 hex characters.

I also changes `year` and `isbn` to string because it simplified form handling on the frontend. This is to be reviewed, but for now it is needed for it to work.