### PR TITLE
Reset created_at on version creation

### DIFF
--- a/app/crud/versions.py
+++ b/app/crud/versions.py
@@ -32,6 +32,7 @@ class CRUDVersions(CRUDBase[AtbdVersions, FullOutput, Create, Update]):
         latest_version.doi = None
         latest_version.citation = None
         latest_version.created_by = user
+        latest_version.created_at = None
         latest_version.last_updated_by = user
         latest_version.published_at = None
         latest_version.published_by = None


### PR DESCRIPTION
The property `created_at` was being copied from one version to another which resulted in all versions having the same created date.
I guess that the version ordering problem came from this.

I also noticed that Draft versions are being returned to anonymous users if they're not the last one in the versions array.
Example:
```
v1.2 -- Pub
v3.0 -- Draft
v2.1 -- Pub
```
This was happening when the versions were out of order, so this fix might solve this problem as a side effect, however this would be something to look into.