### PR TITLE
Add fontspec and set Latin Modern Math as main font in order to allow users to input unicode characters such as as lowercase alpha

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update \
     texlive-latex-recommended \
     texlive-bibtex-extra \
     texlive-xetex \
+    texlive-science \
     latexmk\
     wget libxml2-dev libxmlsec1-dev libxmlsec1-openssl pkg-config gcc \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
Eg: 
![image](https://user-images.githubusercontent.com/11858457/147178016-6100c122-3ba0-4db3-a17a-b2a2fb2c4f7d.png)

In regular PDF: 
![image](https://user-images.githubusercontent.com/11858457/147178047-0a3d5f26-2df5-4524-ac9f-fb7ce84648ff.png)

In journal PDF: 
![image](https://user-images.githubusercontent.com/11858457/147178086-8d057674-688a-48fa-a671-0375dde0da98.png)
