### PR TITLE
Feature/pdf improvements

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -18,8 +18,6 @@ COPY ./app/ /app/app/
 COPY ./setup.py /app/setup.py
 
 # Style file for AGU journal pdf
-#RUN mkdir -p /usr/share/texlive/texmf-dist/tex/xetex/agujournal2019/
-#COPY ./app/pdf/agujournal2019.cls /usr/share/texlive/texmf-dist/tex/xetex/agujournal2019/
 RUN mkdir -p /usr/share/texlive/texmf-dist/tex/latex/agujournal2019/
 COPY ./app/pdf/agujournal2019.cls /usr/share/texlive/texmf-dist/tex/latex/agujournal2019/
 # register the new .cls file

--- a/app/pdf/agujournal2019.cls
+++ b/app/pdf/agujournal2019.cls
@@ -517,25 +517,29 @@
 
 %% Running heads ===>>>
 
-  %% unless we need these, leave these uncommented
-    \let\@mkboth\@gobbletwo
-    \let\chaptermark\@gobble
-    \let\sectionmark\@gobble
-  %%
+  % %% unless we need these, leave these uncommented
+  %   \let\@mkboth\@gobbletwo
+  %   \let\chaptermark\@gobble
+  %   \let\sectionmark\@gobble
+  % %%
 
-\def\ps@headings{\def\@oddfoot{\centerline{\small --\the\c@page--}}
-\let\@evenfoot\@oddfoot
-%% \thejournalname set with \journalname{} command; if not you will get a request to set
-%% the journal name with \journalname{}
-\def\@oddhead{\vbox to 0pt{\vss\centerline{\color{ltgray}\small manuscript
-submitted to {\it \thejournalname}}\vskip24pt}}
-\let\@evenhead\@oddhead
-}
+%% =========================== NOTE: ===================================================
+%% The following `\ps@headings' definition and activation are commented out because they 
+%% have been re-implemented in the PDF generator class. They are implemented there in order 
+%% to make the same custom headings style available to both the regulard and journal PDFs
 
+% \def\ps@headings{\def\@oddfoot{\centerline{\small --\the\c@page--}}
+% \let\@evenfoot\@oddfoot
+% %% \thejournalname set with \journalname{} command; if not you will get a request to set
+% %% the journal name with \journalname{}
+% \def\@oddhead{\vbox to 0pt{\vss\centerline{\color{ltgray}\small manuscript
+% submitted to {\it \thejournalname}}\vskip24pt}}
+% \let\@evenhead\@oddhead
+% }
 
-
-%% After ps@headings is defined, now we use it to activate the definitions
-\ps@headings
+% %% After ps@headings is defined, now we use it to activate the definitions
+% \ps@headings
+%% =========================== / NOTE / ==============================================
 
 %%% Footnotes
 

--- a/app/pdf/generator.py
+++ b/app/pdf/generator.py
@@ -578,12 +578,7 @@ def generate_latex(atbd: Atbds, filepath: str, journal=False):  # noqa: C901
     if journal:
         doc.append(Command("begin", arguments="keypoints"))
         for keypoint in document_data["key_points"].split("\n"):
-            # Some people skip 2 lines between each key point,
-            # which creates and extra, blank, bullet in the Key Points
-            # section of the document Title page.
-            if not keypoint:
-                continue
-            doc.append(Command("item", arguments=keypoint))
+            doc.append(Command("item", arguments=keypoint.strip("-") or " "))
         doc.append(Command("end", arguments="keypoints"))
 
     generate_bib_file(

--- a/app/pdf/generator.py
+++ b/app/pdf/generator.py
@@ -559,6 +559,16 @@ def generate_latex(atbd: Atbds, filepath: str, journal=False):  # noqa: C901
 
     else:
         doc.append(Command("author", arguments=NoEscape("\\and ".join(authors))))
+        doc.append(
+            Command(
+                "date",
+                arguments=NoEscape(
+                    atbd_version.published_at.strftime("%B %d, %Y")
+                    if atbd_version.published_at
+                    else "{{}}"
+                ),
+            )
+        )
         doc.append(Command("maketitle"))
 
     if not journal:

--- a/app/pdf/generator.py
+++ b/app/pdf/generator.py
@@ -573,6 +573,7 @@ def generate_latex(atbd: Atbds, filepath: str, journal=False):  # noqa: C901
 
     if not journal:
         doc.append(Command("tableofcontents"))
+        doc.append(Command("newpage"))
 
     if journal:
         doc.append(Command("begin", arguments="keypoints"))

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ inst_reqs = [
     "awslambdaric==1.2.0",
 ]
 extra_reqs = {
-    "dev": ["pre-commit", "flake8", "black==21.12b0", "mypy", "isort"],
+    "dev": ["pre-commit", "flake8", "black", "mypy", "isort"],
     "deploy": [
         "python-dotenv",
         "aws-cdk.core>=1.136.0",
@@ -57,7 +57,7 @@ extra_reqs = {
 setup(
     name="nasa_apt",
     version="2.2.3-beta",
-    description=u"API for the NASA Algorith Publication Tool",
+    description="API for the NASA Algorith Publication Tool",
     long_description=long_description,
     long_description_content_type="text/markdown",
     python_requires=">=3",
@@ -69,7 +69,7 @@ setup(
         "Programming Language :: Python :: 3.7",
     ],
     keywords="",
-    author=u"Development Seed",
+    author="Development Seed",
     author_email="info@developmentseed.org",
     url="https://github.com/developmentseed/nasa-apt",
     license="MIT",


### PR DESCRIPTION
This PR implements the following features requested in issue #474 : 
|       | Before | Now | PDF Type |
| --- | ------ | ----- | ----------|
| 1.   | PDF displays date generated | PDF displays no date if `status` is not `published` otherwise displays the `published at` date | Regular |
| 2.   | No page break after TOC | Page break after TOC | Regular |
| 3.   | No heading in PDF | Heading in PDF (says: `This ATBD was downloaded from the NASA Algorithm Publication Tool (APT)` | Regular |
| 4.  | Centered heading in PDF only displays: `Manuscript submitted to _Earth and Space Science_` | Centered heading in PDF displays: `Manuscript submitted to _Earth and Space Science_ \n This ATBD was downloaded from the NASA Algorithm Publication Tool (APT)` | Journal |

Screenshots: 
## No date in un-published regular PDF: 
<img width="546" alt="image" src="https://user-images.githubusercontent.com/11858457/162490904-b879df7b-ac3e-439c-80f2-11b5939333b6.png">

## Date in published regular PDF: 
<img width="818" alt="image" src="https://user-images.githubusercontent.com/11858457/162491881-4643ea44-c5b5-4603-a963-f56b19de2a1c.png">


## Page break after TOC in regular PDF: 
<img width="549" alt="image" src="https://user-images.githubusercontent.com/11858457/162490830-07e077aa-ab50-49de-990b-87faa2c72437.png">

## Header in regular PDF:
### Title page:
<img width="546" alt="image" src="https://user-images.githubusercontent.com/11858457/162490904-b879df7b-ac3e-439c-80f2-11b5939333b6.png">

### Other page: 
<img width="546" alt="image" src="https://user-images.githubusercontent.com/11858457/162491044-827c1e52-fc03-490a-bb5d-2316ef0d9dba.png">

## Header in journal PDF: 
### Title page: 
<img width="793" alt="image" src="https://user-images.githubusercontent.com/11858457/162491134-5b9dbe31-6bf3-4feb-94e0-7fef6925f0cb.png">

### Other page: 
<img width="792" alt="image" src="https://user-images.githubusercontent.com/11858457/162491184-e2455b2a-f8c6-4f10-b5cc-38df3d61d5e8.png">
