### PR TITLE
Ensure whitespaces in hyperref text are respected in journal PDF

### DIFF
--- a/app/pdf/agujournal2019.cls
+++ b/app/pdf/agujournal2019.cls
@@ -89,7 +89,11 @@
 
 %% xcolor.sty
 \RequirePackage{xcolor}
-\RequirePackage{url}
+
+%% Comment out the loading of this package as it gets loaded within the 
+%% latex generator class with addition options to ensure that the compiler 
+%% doesn't strip whitespaces from the link text and enables line breaks in the URL
+%\RequirePackage{url}
 
 %% for better track changes
 %\RequirePackage{trackchanges}
@@ -1157,12 +1161,18 @@ width0pt\relax}\\*\noindent\ignorespaces}
 % When using NatBib, this sets brackets for citations:
 %\renewcommand\NAT@open{(} \renewcommand\NAT@close{)}   %xx Parens by default, but not using anyways.  DC
 
-% hyperref MUST be loaded before APACite 
-\PassOptionsToPackage{obeyspaces,hyphens}{url}\RequirePackage{hyperref}
-\urlstyle{same}
-\hypersetup{breaklinks=true,colorlinks=true,linkcolor=blue,filecolor=magenta,urlcolor=blue,citecolor=black}%
+%% ================================= NOTE: =========================================================
+%% hyperref and apacite will be loaded in the pdf generator class since they need to be made 
+%% available to both the journal and regular pdfs 
 
-\RequirePackage{apacite}
+%% hyperref MUST be loaded before APACite 
+%\PassOptionsToPackage{obeyspaces,hyphens}{url}\RequirePackage{hyperref}
+%\urlstyle{same}
+%\hypersetup{breaklinks=true,colorlinks=true,linkcolor=blue,filecolor=magenta,urlcolor=blue,citecolor=black}%
+
+%\RequirePackage{apacite}
+%% ================================= /NOTE/ =========================================================
+
 %\RequirePackage{natbib}
 \let\cite\shortcite %xx So get et al. with three authors the first time.
 %\let\citep\shortcite %xx A natbib command.

--- a/app/pdf/generator.py
+++ b/app/pdf/generator.py
@@ -204,6 +204,7 @@ def process_text_content(
     result = []
     for d in data:
         if d.get("type") == "a":
+            print("HYPERLINK: ", hyperlink(d["url"], d["children"][0]["text"]))
             result.append(hyperlink(d["url"], d["children"][0]["text"]))
         elif d.get("type") == "ref":
             result.append(reference(d["refId"]))
@@ -469,31 +470,29 @@ def generate_latex(atbd: Atbds, filepath: str, journal=False):  # noqa: C901
         doc.packages.append(Package(p))
 
     doc.preamble.append(Command("setmainfont", arguments=NoEscape("Latin Modern Math")))
+
+    # adds a custom light grey colour used for the document heading
     doc.preamble.append(
         Command("definecolor", arguments=["ltgray", "cmyk", ".12,0,0,.3"])
     )
 
-    if not journal:
+    doc.preamble.append(NoEscape("\\PassOptionsToPackage{obeyspaces,hyphens}{url}"))
+    doc.preamble.append(NoEscape("\\usepackage{hyperref}"))
 
-        doc.preamble.append(
-            NoEscape(
-                "\\PassOptionsToPackage{obeyspaces,hyphens}{url}\\usepackage{hyperref}"
-            )
+    doc.preamble.append(
+        Command(
+            "hypersetup",
+            arguments="breaklinks=true,colorlinks=true,linkcolor=blue,filecolor=magenta,urlcolor=blue,citecolor=black",
         )
+    )
+    doc.preamble.append(Command("urlstyle", arguments="same"))
 
-        doc.preamble.append(
-            Command(
-                "hypersetup",
-                arguments="breaklinks=true,colorlinks=true,linkcolor=blue,filecolor=magenta,urlcolor=blue,citecolor=black",
-            )
-        )
-        doc.preamble.append(Command("urlstyle", arguments="same"))
-        # The apacite package is added using the `usepackage` command
-        # instead of the `Package()` function to ensure that apacite
-        # will be loaded after `hyperref` - with breaks things if the
-        # two packages are loaded in the reverse order:
-        # https://tex.stackexchange.com/a/316288
-        doc.preamble.append(Command("usepackage", arguments="apacite"))
+    # The apacite package is added using the `usepackage` command
+    # instead of the `Package()` function to ensure that apacite
+    # will be loaded after `hyperref` - with breaks things if the
+    # two packages are loaded in the reverse order:
+    # https://tex.stackexchange.com/a/316288
+    doc.preamble.append(Command("usepackage", arguments="apacite"))
 
     if journal:
 

--- a/app/pdf/generator.py
+++ b/app/pdf/generator.py
@@ -204,7 +204,6 @@ def process_text_content(
     result = []
     for d in data:
         if d.get("type") == "a":
-            print("HYPERLINK: ", hyperlink(d["url"], d["children"][0]["text"]))
             result.append(hyperlink(d["url"], d["children"][0]["text"]))
         elif d.get("type") == "ref":
             result.append(reference(d["refId"]))


### PR DESCRIPTION
Addresses #490:

- Hyperref in Journal PDF now respects whitespace: 
<img width="916" alt="image" src="https://user-images.githubusercontent.com/11858457/162817321-03d8e40c-0682-48fd-8774-197f5a65434e.png">

