### PR TITLE
Add file permissions to latex style class in Dockerfile

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -19,6 +19,7 @@ COPY ./setup.py /app/setup.py
 
 # Style file for AGU journal pdf
 RUN mkdir -p /usr/share/texlive/texmf-dist/tex/latex/agujournal2019/
+RUN chmod 644 ./app/pdf/agujournal2019.cls
 COPY ./app/pdf/agujournal2019.cls /usr/share/texlive/texmf-dist/tex/latex/agujournal2019/
 # register the new .cls file
 RUN mktexlsr 

--- a/app/pdf/error_handler.py
+++ b/app/pdf/error_handler.py
@@ -351,15 +351,18 @@ def generate_html_content_for_error(
     parser = LogCheck()
     parser.lines = full_error
 
-    errs = list(parser.errors)
-    parsed_errors = [
-        "<p>Unable to parse error message. Please see below for full output</p>"
-    ]
-    if errs:
+    try:
+        parsed_errors = [
+            f"{e['text']}<br>Line {e.get('line', 'UNKOWN')}: error code {e.get('code', 'UNKOWN')}"
+            for e in list(parser.errors)
+        ]
+    except Exception:
         parsed_errors = []
-        for e in errs:
-            e.setdefault("line", "-")
-            parsed_errors.append(f"{e['text']}<br>Line {e['line']}: {e['code']}")
+
+    if not parsed_errors:
+        parsed_errors = [
+            "<p>Unable to parse error message. Please see below for full output</p>"
+        ]
 
     with open("./app/pdf/error.html", "r") as f:
         error_html = f.read()


### PR DESCRIPTION
Bugfix to address 2 layered issues: 

1. (Core issue): When building the Lambda container image, the AGU Latex Style Class (`app/pdf/agujournal2019.cls`) gets copied over to the Docker execution context (under `/usr/share/texlive/texmf-dist/`) and "registered" as a LaTeX document class by running `mktexlsr`. However, if, for any reason, the file doesn't have at least read permissions for the `group` user, the `agujournal2019` class file will not be found by LaTeX when generating a journal document. This has been addressed by adding the line: `RUN chmod 644 ./app/pdf/agujournal2019.cls ` to the docker file, to ensure the file has the necessary permissions before being copied over to the `texmf-dist` sub-folder.
2.  This error was indeed caught, however, for some reason, the LaTeX error parsing logic was not correctly extracting an error code for the error, and was then failing when building the HTML error page. To resolve this, I've wrapped the logic that formats the parsed error message in a try/catch and let it default to a generic message (`Unable to parse error message`) if the exception is reached, or if no errors are successfully parsed. I've also made the `line` and `code` properties of the parsed error message optional, so as to have a better chance of displaying the parsed error message, even if we can't successfully extract the line number or code (for example, in this case, the error has to do with a missing LaTeX style class and therefore doesn't have a line number from the document associated to it, however, there is a parse-able error message, which is better than nothing!)