### PR TITLE
Store inline equations

### DIFF
--- a/app/pdf/generator.py
+++ b/app/pdf/generator.py
@@ -400,6 +400,11 @@ def process(
         eq = data["children"][0]["text"].replace("\\\\", "\\")
         return NoEscape(f"\\begin{{equation}}{eq}\\end{{equation}}")
 
+    if data.get("type") == "equation-inline":
+        eq = data["children"][0]["text"].replace("\\\\", "\\")
+        # Wrap equation in a single `$` char to enable inline equation
+        return NoEscape(f"${eq}$")
+
         # return Math(data=NoEscape(data["children"][0]["text"].replace("\\\\", "\\")))
 
     if data.get("type") == "image-block":
@@ -665,10 +670,13 @@ def generate_latex(atbd: Atbds, filepath: str, journal=False):  # noqa: C901
 
         if section_name == "abstract":
             doc.append(Command("begin", "abstract"))
-            if not document_data.get(section_name):
-                doc.append("Abstract Unavailable")
-            else:
-                doc.append(document_data[section_name])
+
+            for item in document_data[section_name].get(
+                "children", [CONTENT_UNAVAILABLE]
+            ):
+                doc.append(NoEscape("\n"))
+                doc.append(process(item, atbd_id=atbd.id))
+
             doc.append(Command("end", "abstract"))
             continue
 
@@ -704,9 +712,9 @@ def generate_latex(atbd: Atbds, filepath: str, journal=False):  # noqa: C901
             # section header means that no content is needed
             continue
 
-        if section_name == "plain_summary":
-            doc.append(document_data[section_name])
-            continue
+        # if section_name == "plain_summary":
+        #     doc.append(document_data[section_name])
+        #     continue
 
         if section_name == "keywords" and atbd_version.keywords:
             doc.append(Command("begin", arguments="itemize"))

--- a/app/pdf/generator.py
+++ b/app/pdf/generator.py
@@ -195,7 +195,12 @@ def wrap_text(data: document.TextLeaf) -> NoEscape:
 
 
 def process_text_content(
-    data: Union[document.TextLeaf, document.ReferenceNode, document.LinkNode]
+    data: Union[
+        document.TextLeaf,
+        document.ReferenceNode,
+        document.LinkNode,
+        document.EquationInlineNode,
+    ]
 ) -> List[NoEscape]:
     """
     Returns a list of text base elements (text, reference or hyperlink)
@@ -207,9 +212,19 @@ def process_text_content(
             result.append(hyperlink(d["url"], d["children"][0]["text"]))
         elif d.get("type") == "ref":
             result.append(reference(d["refId"]))
+        elif d.get("type") == "equation-inline":
+            result.append(NoEscape(f'${d["children"][0]["text"]}$'))
         else:
             result.append(wrap_text(d))
     return result
+
+
+"""
+if data.get("type") == "equation-inline":
+        eq = data["children"][0]["text"].replace("\\\\", "\\")
+        # Wrap equation in a single `$` char to enable inline equation
+        return NoEscape()
+"""
 
 
 def process_data_access_url(access_url: document.DataAccessUrl) -> List[NoEscape]:
@@ -399,13 +414,6 @@ def process(
     if data.get("type") == "equation":
         eq = data["children"][0]["text"].replace("\\\\", "\\")
         return NoEscape(f"\\begin{{equation}}{eq}\\end{{equation}}")
-
-    if data.get("type") == "equation-inline":
-        eq = data["children"][0]["text"].replace("\\\\", "\\")
-        # Wrap equation in a single `$` char to enable inline equation
-        return NoEscape(f"${eq}$")
-
-        # return Math(data=NoEscape(data["children"][0]["text"].replace("\\\\", "\\")))
 
     if data.get("type") == "image-block":
         [img] = filter(lambda d: d["type"] == "img", data["children"])

--- a/app/pdf/generator.py
+++ b/app/pdf/generator.py
@@ -219,14 +219,6 @@ def process_text_content(
     return result
 
 
-"""
-if data.get("type") == "equation-inline":
-        eq = data["children"][0]["text"].replace("\\\\", "\\")
-        # Wrap equation in a single `$` char to enable inline equation
-        return NoEscape()
-"""
-
-
 def process_data_access_url(access_url: document.DataAccessUrl) -> List[NoEscape]:
     """
     Returns a list of Latex formatted commands, to be appended in order

--- a/app/schemas/document.py
+++ b/app/schemas/document.py
@@ -275,6 +275,7 @@ class SectionWrapper(BaseModel):
             TableBlockNode,
             SubsectionNode,
             EquationNode,
+            EquationInlineNode,
             DivNode,
         ]
     ]

--- a/app/schemas/document.py
+++ b/app/schemas/document.py
@@ -84,14 +84,14 @@ class EquationInlineNode(BaseNode):
     """Inline Equation WYSIWYG node"""
 
     type: Literal[TypesEnum.equation_inline]
-    isInline: Optional[bool]
+    # isInline: Optional[bool]
 
 
 class DivNode(BaseNode):
     """Generic text container WYSIWYG node"""
 
     type: Literal[TypesEnum.div]
-    children: List[Union[LinkNode, ReferenceNode, TextLeaf, EquationInlineNode]]
+    children: List[Union[LinkNode, ReferenceNode, EquationInlineNode, TextLeaf]]
 
 
 class OrderedListNode(BaseNode):
@@ -134,7 +134,6 @@ class EquationNode(BaseNode):
     """Equation WYSIWYG node"""
 
     type: Literal[TypesEnum.equation]
-    isInline: Optional[bool]
 
 
 class ImageNode(BaseNode):
@@ -275,7 +274,6 @@ class SectionWrapper(BaseModel):
             TableBlockNode,
             SubsectionNode,
             EquationNode,
-            EquationInlineNode,
             DivNode,
         ]
     ]
@@ -326,7 +324,7 @@ class Document(DocumentSummary):
         "data_access_output_data",
         "data_access_related_urls",
     )
-    def _print(cls, v):
+    def _filter_incomplete_objects(cls, v):
         if not v:
             return []
         # Filter out items that are missing both URL and Description

--- a/app/schemas/document.py
+++ b/app/schemas/document.py
@@ -20,6 +20,7 @@ class TypesEnum(str, Enum):
     unordered_list = "ul"
     subsection = "sub-section"
     equation = "equation"
+    equation_inline = "equation-inline"
     image = "img"
     image_block = "image-block"
     table_cell = "td"
@@ -79,11 +80,18 @@ class ReferenceNode(BaseNode):
     refId: str
 
 
+class EquationInlineNode(BaseNode):
+    """Inline Equation WYSIWYG node"""
+
+    type: Literal[TypesEnum.equation_inline]
+    isInline: Optional[bool]
+
+
 class DivNode(BaseNode):
     """Generic text container WYSIWYG node"""
 
     type: Literal[TypesEnum.div]
-    children: List[Union[LinkNode, ReferenceNode, TextLeaf]]
+    children: List[Union[LinkNode, ReferenceNode, TextLeaf, EquationInlineNode]]
 
 
 class OrderedListNode(BaseNode):
@@ -126,6 +134,7 @@ class EquationNode(BaseNode):
     """Equation WYSIWYG node"""
 
     type: Literal[TypesEnum.equation]
+    isInline: Optional[bool]
 
 
 class ImageNode(BaseNode):

--- a/app/schemas/elasticsearch.py
+++ b/app/schemas/elasticsearch.py
@@ -60,6 +60,9 @@ class ElasticsearchAtbdVersion(BaseModel):
             if isinstance(d, _document.EquationNode):
                 return
 
+            if isinstance(d, _document.EquationInlineNode):
+                return
+
             if any(
                 isinstance(d, i)
                 for i in (

--- a/app/schemas/versions.py
+++ b/app/schemas/versions.py
@@ -195,6 +195,9 @@ class FullOutput(AtbdVersionSummaryOutput):
             if isinstance(d, _document.EquationNode):
                 return PublicationUnits(images=0, tables=0, words=1)
 
+            if isinstance(d, _document.EquationInlineNode):
+                return PublicationUnits(images=0, tables=0, words=1)
+
             if isinstance(d, _document.TableNode):
                 return PublicationUnits(images=0, tables=1, words=0)
 


### PR DESCRIPTION
For inline equations, I have added a new node type in the frontend, which will be POSTed to the backend in the following form:

```
{
  "type": "equation-inline",
  "isInline": true,
  "children": [
    {"text": "e=mc^2}
  ]
}
```

With the changes in this PR and when I POST a document containing an inline equation, I get a success response but the inline equation is not returned with the document in the response. Likewise when I reload the page after saving the inline equation is not present. 

I'm sure I'm missing something, could you point me in the right direction. 