### PR TITLE
Raise error only when ATBD alias is updated

### DIFF
--- a/app/api/v2/atbds.py
+++ b/app/api/v2/atbds.py
@@ -139,7 +139,7 @@ def update_atbd(
         principals=principals, action="update", atbd=atbd, all_versions=False
     )
 
-    if atbd_input.alias and any([v.status == "PUBLISHED" for v in atbd.versions]):
+    if atbd.alias != atbd_input.alias and any([v.status == "PUBLISHED" for v in atbd.versions]):
         raise HTTPException(
             status_code=400,
             detail="Update not allowed for an ATBD with a published version",


### PR DESCRIPTION
Fixes https://github.com/NASA-IMPACT/nasa-apt/issues/504

The error is raised for published versions if the request payload to update the ATDB contains an `alias` value. The front-end always submits the value even though the value cannot be change in the front-end.

Extending the condition to check whether the `alias` value in the database is different from the value provided in the payload before raising the exception. 