### PR TITLE
Check if alias exists before checking length

### DIFF
--- a/app/schemas/atbds.py
+++ b/app/schemas/atbds.py
@@ -16,12 +16,12 @@ class Update(BaseModel):
     title: Optional[str]
 
     @validator("alias")
-    def _restrict_to_32_chars(cls, v):
-        if len(v) > 32:
+    def _restrict_to_32_chars(cls, alias):
+        if alias and len(alias) > 32:
             raise HTTPException(
                 status_code=400, detail="Alias cannot be longer than 32 characters"
             )
-        return v
+        return alias
 
 
 class Create(BaseModel):


### PR DESCRIPTION
We were unable to update documents that don't have an alias specified, ie. the alias value is submitted `null`.

Fixing the problem by checking if `alias` actually has a value. Also renaming `v` to `alias` for better readability. 