### PR TITLE
Allow locked ATBD versions

### DIFF
--- a/app/crud/versions.py
+++ b/app/crud/versions.py
@@ -1,13 +1,28 @@
 """CRUD operations for ATBD Versions."""
 
+from sqlalchemy.orm import Session
+
 from app.crud.base import CRUDBase
 from app.db.db_session import DbSession
 from app.db.models import Atbds, AtbdVersions
-from app.schemas.versions import Create, FullOutput, Update
+from app.schemas.versions import Create, FullOutput, Update, LockUpdate
 
 
 class CRUDVersions(CRUDBase[AtbdVersions, FullOutput, Create, Update]):
     """CRUDVersions"""
+
+    def set_lock(
+        self, db: Session, *, version: AtbdVersions, obj_in: LockUpdate
+    ):
+        """Queries the item in the DB, updates the class's attributes and
+        re-inserts into the DB."""
+        update_data = obj_in.dict(exclude_unset=True, exclude_none=False)
+        setattr(version, 'locked_by', update_data['locked_by'])
+
+        db.add(version)
+        db.commit()
+        db.refresh(version)
+        return version
 
     def delete(self, db: DbSession, atbd: Atbds, version: AtbdVersions):
         """

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -89,6 +89,7 @@ class AtbdVersions(Base):
     reviewers = Column(postgresql.ARRAY(postgresql.JSONB), server_default="{{}}")
     journal_status = Column(String())
     keywords = Column(postgresql.ARRAY(postgresql.JSONB), server_default="{{}}")
+    locked_by = Column(String(), nullable=True)
 
     def __repr__(self):
         """String representation"""

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,8 @@
 from app import config
 from app.api.v2.api import api_router
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
 
 from starlette.middleware.cors import CORSMiddleware
 from starlette.middleware.gzip import GZipMiddleware

--- a/app/schemas/versions.py
+++ b/app/schemas/versions.py
@@ -341,4 +341,4 @@ class AdminUpdate(Update):
 
 
 class LockUpdate(BaseModel):
-    locked_by: str
+    locked_by: Union[str, None]

--- a/app/schemas/versions.py
+++ b/app/schemas/versions.py
@@ -338,3 +338,7 @@ class AdminUpdate(Update):
     # since from the API side, each reviewer should have
     # a review status associated with their user sub
     reviewers: Optional[List[Dict[str, str]]]  # type: ignore
+
+
+class LockUpdate(BaseModel):
+    locked_by: str

--- a/app/users/cognito.py
+++ b/app/users/cognito.py
@@ -258,6 +258,15 @@ def list_cognito_users(groups="curator,contributor"):
     return (app_users, str(uuid4()))
 
 
+def get_cognito_user(sub: str):
+    client = cognito_client()
+    user = client.admin_get_user(
+        UserPoolId=config.USER_POOL_ID,
+        Username=sub
+    )
+    return user
+
+
 def process_users_input(
     version_input: versions.Update,
     atbd_version: AtbdVersions,

--- a/db/deploy/version_lock.sql
+++ b/db/deploy/version_lock.sql
@@ -1,0 +1,9 @@
+-- Deploy nasa-apt:version_lock to pg
+-- requires: tables
+
+BEGIN;
+
+ALTER TABLE apt.atbd_versions
+    ADD COLUMN "locked_by" VARCHAR(1024);
+
+COMMIT;

--- a/db/revert/version_lock.sql
+++ b/db/revert/version_lock.sql
@@ -1,0 +1,8 @@
+-- Revert nasa-apt:version_lock from pg
+
+BEGIN;
+
+ALTER TABLE apt.atbd_versions
+    DROP COLUMN "locked_by";
+
+COMMIT;

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -21,3 +21,4 @@ drop_contact_roles [contact_roles] 2021-11-15T19:16:45Z Leo Thomas <leo@MacBook-
 @v2.1.0-beta 2021-12-03T15:28:49Z Leo Thomas <leo@MacBook-Pro.lan> # Tag v2.1.0-beta release 2021_12_03
 
 summary_abstract_rich_text 2022-04-26T15:17:32Z Leo Thomas <leo@MacBook-Pro-2.local> # Convert the abstract and plain_summary fields of the document object to rich text objects
+version_lock [tables] 2022-06-01T06:57:35Z Oliver Roick <oroick@192-168-1-106.tpgi.com.au> # Add locked_by field to atbd_versions

--- a/db/verify/version_lock.sql
+++ b/db/verify/version_lock.sql
@@ -1,0 +1,7 @@
+-- Verify nasa-apt:version_lock on pg
+
+BEGIN;
+
+-- XXX Add verifications here.
+
+ROLLBACK;


### PR DESCRIPTION
Contributes to https://github.com/NASA-IMPACT/nasa-apt/issues/454

- Adds new field `locked_by` to the versions table, we use that to store the user sub of the use that has currently locked the ATBD version
- Adds new API endpoint `/atbds/{atbd_id}/versions/{version}/lock`
  - Checks if the ATBD version is currently locked and by whom, returns HTTP 409 if another user has locked the ATBD version
  - Sets the lock otherwise and returns success response
