### PR TITLE
Lock with permissions model

### DIFF
--- a/app/acls.py
+++ b/app/acls.py
@@ -4,9 +4,6 @@ from typing import Dict, List, Tuple
 import fastapi_permissions
 
 ATBD_VERSION_ACLS: Dict = {
-    fastapi_permissions.Everyone: [
-        {"action": "view", "conditions": {"status": "PUBLISHED"}}
-    ],
     "owner": [
         {"action": "view"},
         {"action": "delete", "conditions": {"status": ["DRAFT"]}},
@@ -35,19 +32,20 @@ ATBD_VERSION_ACLS: Dict = {
         {"action": "join_authors", "deny": True},
         {"action": "edit"},
         {"action": "offer_ownership"},
-        {
-            "action": "update",
-            "conditions": {
-                "status": [
-                    "DRAFT",
-                    "CLOSED_REVIEW_REQUESTED",
-                    "OPEN_REVIEW",
-                    "PUBLICATION_REQUESTED",
-                    "PUBLICATION",
-                    "PUBLISHED",
-                ],
-            },
-        },
+        # {
+        #     "action": "update",
+        #     "conditions": {
+        #         "locked_by": [None],
+        #         "status": [
+        #             "DRAFT",
+        #             "CLOSED_REVIEW_REQUESTED",
+        #             "OPEN_REVIEW",
+        #             "PUBLICATION_REQUESTED",
+        #             "PUBLICATION",
+        #             "PUBLISHED",
+        #         ],
+        #     },
+        # },
         {
             "action": "secure_lock",
             "conditions": {
@@ -75,19 +73,20 @@ ATBD_VERSION_ACLS: Dict = {
         {"action": "view"},
         {"action": "comment"},
         {"action": "edit"},
-        {
-            "action": "update",
-            "conditions": {
-                "status": [
-                    "DRAFT",
-                    "CLOSED_REVIEW_REQUESTED",
-                    "OPEN_REVIEW",
-                    "PUBLICATION_REQUESTED",
-                    "PUBLICATION",
-                    "PUBLISHED",
-                ],
-            },
-        },
+        # {
+        #     "action": "update",
+        #     "conditions": {
+        #         "locked_by": [None],
+        #         "status": [
+        #             "DRAFT",
+        #             "CLOSED_REVIEW_REQUESTED",
+        #             "OPEN_REVIEW",
+        #             "PUBLICATION_REQUESTED",
+        #             "PUBLICATION",
+        #             "PUBLISHED",
+        #         ],
+        #     },
+        # },
         {
             "action": "secure_lock",
             "conditions": {
@@ -129,6 +128,19 @@ ATBD_VERSION_ACLS: Dict = {
         # granted `secure_lock`, as the lock owner
         {"action": "secure_lock"},
         {"action": "release_lock"},
+        {
+            "action": "update",
+            "conditions": {
+                "status": [
+                    "DRAFT",
+                    "CLOSED_REVIEW_REQUESTED",
+                    "OPEN_REVIEW",
+                    "PUBLICATION_REQUESTED",
+                    "PUBLICATION",
+                    "PUBLISHED",
+                ],
+            },
+        },
     ],
     "reviewers": [
         {"action": "view"},
@@ -196,6 +208,9 @@ ATBD_VERSION_ACLS: Dict = {
             "conditions": {"status": ["PUBLICATION_REQUESTED"]},
         },
         {"action": "publish", "conditions": {"status": ["PUBLICATION"]}},
+    ],
+    fastapi_permissions.Everyone: [
+        {"action": "view", "conditions": {"status": ["PUBLISHED"]}}
     ],
 }
 

--- a/app/acls.py
+++ b/app/acls.py
@@ -4,22 +4,31 @@ from typing import Dict, List, Tuple
 import fastapi_permissions
 
 ATBD_VERSION_ACLS: Dict = {
-    fastapi_permissions.Everyone: [{"action": "view", "status": "PUBLISHED"}],
+    fastapi_permissions.Everyone: [
+        {"action": "view", "conditions": {"status": "PUBLISHED"}}
+    ],
     "owner": [
         {"action": "view"},
-        {"action": "delete", "status": ["DRAFT"]},
-        {"action": "request_closed_review", "status": ["DRAFT"]},
+        {"action": "delete", "conditions": {"status": ["DRAFT"]}},
+        {"action": "request_closed_review", "conditions": {"status": ["DRAFT"]}},
         {
             "action": "cancel_closed_review_request",
-            "status": ["CLOSED_REVIEW_REQUESTED"],
+            "conditions": {
+                "status": ["CLOSED_REVIEW_REQUESTED"],
+            },
         },
-        {"action": "request_publication", "status": ["OPEN_REVIEW"]},
-        {"action": "cancel_publication_request", "status": ["PUBLICATION_REQUESTED"]},
-        {"action": "create_new_version", "status": ["PUBLISHED"]},
-        {"action": "bump_minor_version", "status": ["PUBLISHED"]},
+        {"action": "request_publication", "conditions": {"status": ["OPEN_REVIEW"]}},
+        {
+            "action": "cancel_publication_request",
+            "conditions": {"status": ["PUBLICATION_REQUESTED"]},
+        },
+        {"action": "create_new_version", "conditions": {"status": ["PUBLISHED"]}},
+        {"action": "bump_minor_version", "conditions": {"status": ["PUBLISHED"]}},
         {
             "action": "update_journal_publication_status",
-            "status": ["PUBLICATION", "PUBLISHED"],
+            "conditions": {
+                "status": ["PUBLICATION", "PUBLISHED"],
+            },
         },
         {"action": "update_journal_status"},
         {"action": "join_reviewers", "deny": True},
@@ -28,15 +37,32 @@ ATBD_VERSION_ACLS: Dict = {
         {"action": "offer_ownership"},
         {
             "action": "update",
-            "status": [
-                "DRAFT",
-                "CLOSED_REVIEW_REQUESTED",
-                "OPEN_REVIEW",
-                "PUBLICATION_REQUESTED",
-                "PUBLICATION",
-                "PUBLISHED",
-            ],
+            "conditions": {
+                "status": [
+                    "DRAFT",
+                    "CLOSED_REVIEW_REQUESTED",
+                    "OPEN_REVIEW",
+                    "PUBLICATION_REQUESTED",
+                    "PUBLICATION",
+                    "PUBLISHED",
+                ],
+            },
         },
+        {
+            "action": "secure_lock",
+            "conditions": {
+                "locked_by": [None],
+                "status": [
+                    "DRAFT",
+                    "CLOSED_REVIEW_REQUESTED",
+                    "OPEN_REVIEW",
+                    "PUBLICATION_REQUESTED",
+                    "PUBLICATION",
+                    "PUBLISHED",
+                ],
+            },
+        },
+        {"action": "override_release_lock"},
         {"action": "invite_authors"},
         {"action": "view_owner"},
         {"action": "view_authors"},
@@ -51,20 +77,39 @@ ATBD_VERSION_ACLS: Dict = {
         {"action": "edit"},
         {
             "action": "update",
-            "status": [
-                "DRAFT",
-                "CLOSED_REVIEW_REQUESTED",
-                "OPEN_REVIEW",
-                "PUBLICATION_REQUESTED",
-                "PUBLICATION",
-                "PUBLISHED",
-            ],
+            "conditions": {
+                "status": [
+                    "DRAFT",
+                    "CLOSED_REVIEW_REQUESTED",
+                    "OPEN_REVIEW",
+                    "PUBLICATION_REQUESTED",
+                    "PUBLICATION",
+                    "PUBLISHED",
+                ],
+            },
         },
-        {"action": "create_new_version", "status": ["PUBLISHED"]},
-        {"action": "bump_minor_version", "status": ["PUBLISHED"]},
+        {
+            "action": "secure_lock",
+            "conditions": {
+                "locked_by": [None],
+                "status": [
+                    "DRAFT",
+                    "CLOSED_REVIEW_REQUESTED",
+                    "OPEN_REVIEW",
+                    "PUBLICATION_REQUESTED",
+                    "PUBLICATION",
+                    "PUBLISHED",
+                ],
+            },
+        },
+        {"action": "override_release_lock"},
+        {"action": "create_new_version", "conditions": {"status": ["PUBLISHED"]}},
+        {"action": "bump_minor_version", "conditions": {"status": ["PUBLISHED"]}},
         {
             "action": "update_journal_publication_status",
-            "status": ["PUBLICATION", "PUBLISHED"],
+            "conditions": {
+                "status": ["PUBLICATION", "PUBLISHED"],
+            },
         },
         {"action": "update_journal_status"},
         {"action": "view_owner"},
@@ -73,12 +118,24 @@ ATBD_VERSION_ACLS: Dict = {
         {"action": "view_comments"},
         {"action": "comment"},
     ],
+    "lock_owner": [
+        # grant `secure_lock` to the lock owner to ensure idempotency of the
+        # PUT /lock operation (lock owner should be able to request secure the
+        # lock on an ATBD version lock they already own withour raising an
+        # exception). The permissions will be granted sequentially, so
+        # the lock_owner, who is also part of the "authors" or "owners" group
+        # fill first be granted `secure_lock` only if the locked_by field is
+        # None (which it isn't, since they've locked it), and then will be
+        # granted `secure_lock`, as the lock owner
+        {"action": "secure_lock"},
+        {"action": "release_lock"},
+    ],
     "reviewers": [
         {"action": "view"},
         {"action": "recieve_ownership", "deny": True},
         {"action": "join_authors", "deny": True},
         {"action": "comment"},
-        {"action": "update_review_status", "status": ["CLOSED_REVIEW"]},
+        {"action": "update_review_status", "conditions": {"status": ["CLOSED_REVIEW"]}},
         {"action": "view_owner"},
         {"action": "view_authors"},
         {"action": "view_reviewers"},
@@ -104,28 +161,41 @@ ATBD_VERSION_ACLS: Dict = {
         {"action": "update"},
         {
             "action": "invite_reviewers",
-            "status": [
-                "CLOSED_REVIEW_REQUESTED",
-                "CLOSED_REVIEW",
-                "OPEN_REVIEW",
-                "PUBLICATION_REQUESTED",
-                "PUBLICATION",
-                "PUBLISHED",
-            ],
+            "conditions": {
+                "status": [
+                    "CLOSED_REVIEW_REQUESTED",
+                    "CLOSED_REVIEW",
+                    "OPEN_REVIEW",
+                    "PUBLICATION_REQUESTED",
+                    "PUBLICATION",
+                    "PUBLISHED",
+                ],
+            },
         },
         {"action": "invite_authors"},
         {"action": "offer_ownership"},
         {"action": "delete"},
         {"action": "delete_thread"},
-        {"action": "deny_closed_review_request", "status": ["CLOSED_REVIEW_REQUESTED"]},
+        {
+            "action": "deny_closed_review_request",
+            "conditions": {"status": ["CLOSED_REVIEW_REQUESTED"]},
+        },
         {
             "action": "accept_closed_review_request",
-            "status": ["CLOSED_REVIEW_REQUESTED"],
+            "conditions": {
+                "status": ["CLOSED_REVIEW_REQUESTED"],
+            },
         },
-        {"action": "open_review", "status": ["CLOSED_REVIEW"]},
-        {"action": "deny_publication_request", "status": ["PUBLICATION_REQUESTED"]},
-        {"action": "accept_publication_request", "status": ["PUBLICATION_REQUESTED"]},
-        {"action": "publish", "status": ["PUBLICATION"]},
+        {"action": "open_review", "conditions": {"status": ["CLOSED_REVIEW"]}},
+        {
+            "action": "deny_publication_request",
+            "conditions": {"status": ["PUBLICATION_REQUESTED"]},
+        },
+        {
+            "action": "accept_publication_request",
+            "conditions": {"status": ["PUBLICATION_REQUESTED"]},
+        },
+        {"action": "publish", "conditions": {"status": ["PUBLICATION"]}},
     ],
 }
 

--- a/app/acls.py
+++ b/app/acls.py
@@ -4,6 +4,31 @@ from typing import Dict, List, Tuple
 import fastapi_permissions
 
 ATBD_VERSION_ACLS: Dict = {
+    "lock_owner": [
+        # grant `secure_lock` to the lock owner to ensure idempotency of the
+        # PUT /lock operation (lock owner should be able to request secure the
+        # lock on an ATBD version lock they already own withour raising an
+        # exception). The permissions will be granted sequentially, so
+        # the lock_owner, who is also part of the "authors" or "owners" group
+        # fill first be granted `secure_lock` only if the locked_by field is
+        # None (which it isn't, since they've locked it), and then will be
+        # granted `secure_lock`, as the lock owner
+        {"action": "secure_lock"},
+        {"action": "release_lock"},
+        {
+            "action": "update",
+            "conditions": {
+                "status": [
+                    "DRAFT",
+                    "CLOSED_REVIEW_REQUESTED",
+                    "OPEN_REVIEW",
+                    "PUBLICATION_REQUESTED",
+                    "PUBLICATION",
+                    "PUBLISHED",
+                ],
+            },
+        },
+    ],
     "owner": [
         {"action": "view"},
         {"action": "delete", "conditions": {"status": ["DRAFT"]}},
@@ -116,31 +141,6 @@ ATBD_VERSION_ACLS: Dict = {
         {"action": "view_curators"},
         {"action": "view_comments"},
         {"action": "comment"},
-    ],
-    "lock_owner": [
-        # grant `secure_lock` to the lock owner to ensure idempotency of the
-        # PUT /lock operation (lock owner should be able to request secure the
-        # lock on an ATBD version lock they already own withour raising an
-        # exception). The permissions will be granted sequentially, so
-        # the lock_owner, who is also part of the "authors" or "owners" group
-        # fill first be granted `secure_lock` only if the locked_by field is
-        # None (which it isn't, since they've locked it), and then will be
-        # granted `secure_lock`, as the lock owner
-        {"action": "secure_lock"},
-        {"action": "release_lock"},
-        {
-            "action": "update",
-            "conditions": {
-                "status": [
-                    "DRAFT",
-                    "CLOSED_REVIEW_REQUESTED",
-                    "OPEN_REVIEW",
-                    "PUBLICATION_REQUESTED",
-                    "PUBLICATION",
-                    "PUBLISHED",
-                ],
-            },
-        },
     ],
     "reviewers": [
         {"action": "view"},

--- a/app/api/v2/atbds.py
+++ b/app/api/v2/atbds.py
@@ -31,6 +31,7 @@ def list_atbds(
 ):
     """Lists all ATBDs with summary version info (only versions with status
     `Published` will be displayed if the user is not logged in)"""
+
     if role:
         if not user:
             raise HTTPException(

--- a/app/api/v2/atbds.py
+++ b/app/api/v2/atbds.py
@@ -44,9 +44,9 @@ def list_atbds(
     # TODO: use a generator and only yield non `None` objects?
 
     atbds = [
-        filter_atbd_versions(principals, atbd, error=False)
+        filter_atbd_versions(principals, atbd, raise_exception=False)
         for atbd in crud_atbds.scan(db=db, role=role, status=status)
-        if filter_atbd_versions(principals, atbd, error=False) is not None
+        if filter_atbd_versions(principals, atbd, raise_exception=False) is not None
     ]
 
     for atbd in atbds:

--- a/app/api/v2/threads.py
+++ b/app/api/v2/threads.py
@@ -113,7 +113,7 @@ def get_threads_stats(
             principals=principals,
             action="view",
             acl=r.AtbdVersions.__acl__(),
-            error=False,
+            raise_exception=False,
         )
     ]
 

--- a/app/api/v2/users.py
+++ b/app/api/v2/users.py
@@ -51,7 +51,7 @@ def list_users(
                 principals=get_active_user_principals(user),
                 action="receive_ownership",
                 acl=version_acl,
-                error=False,
+                raise_exception=False,
             )
         ]
     if user_filter == "invite_authors":
@@ -66,7 +66,7 @@ def list_users(
                 principals=get_active_user_principals(user),
                 action="join_authors",
                 acl=version_acl,
-                error=False,
+                raise_exception=False,
             )
         ]
     if user_filter == "invite_reviewers":
@@ -81,7 +81,7 @@ def list_users(
                 principals=get_active_user_principals(user),
                 action="join_reviewers",
                 acl=version_acl,
-                error=False,
+                raise_exception=False,
             )
         ]
 

--- a/app/api/v2/versions.py
+++ b/app/api/v2/versions.py
@@ -257,6 +257,7 @@ def secure_atbd_version_lock(
     atbd_id: str,
     version: str,
     db: DbSession = Depends(get_db_session),
+    override: bool = False,
     user: CognitoUser = Depends(require_user),
     principals=Depends(get_active_user_principals),
 ):
@@ -272,7 +273,7 @@ def secure_atbd_version_lock(
     atbd_version: AtbdVersions
     [atbd_version] = atbd.versions
 
-    if not check_permissions(
+    if not override and not check_permissions(
         principals=principals,
         action="secure_lock",
         acl=atbd_version.__acl__(),
@@ -305,7 +306,6 @@ def secure_atbd_version_lock(
 def release_atbd_version_lock(
     atbd_id: str,
     version: str,
-    override: bool = False,
     db: DbSession = Depends(get_db_session),
     user: CognitoUser = Depends(require_user),
     principals=Depends(get_active_user_principals),
@@ -331,7 +331,7 @@ def release_atbd_version_lock(
     if atbd_version.locked_by is None:
         return {}
 
-    if not override and not check_permissions(
+    if not check_permissions(
         principals=principals,
         action="release_lock",
         acl=atbd_version.__acl__(),

--- a/app/crud/versions.py
+++ b/app/crud/versions.py
@@ -1,13 +1,28 @@
 """CRUD operations for ATBD Versions."""
 
+from sqlalchemy.orm import Session
+
 from app.crud.base import CRUDBase
 from app.db.db_session import DbSession
 from app.db.models import Atbds, AtbdVersions
-from app.schemas.versions import Create, FullOutput, Update
+from app.schemas.versions import Create, FullOutput, Update, LockUpdate
 
 
 class CRUDVersions(CRUDBase[AtbdVersions, FullOutput, Create, Update]):
     """CRUDVersions"""
+
+    def set_lock(
+        self, db: Session, *, version: AtbdVersions, obj_in: LockUpdate
+    ):
+        """Queries the item in the DB, updates the class's attributes and
+        re-inserts into the DB."""
+        update_data = obj_in.dict(exclude_unset=True, exclude_none=False)
+        setattr(version, 'locked_by', update_data['locked_by'])
+
+        db.add(version)
+        db.commit()
+        db.refresh(version)
+        return version
 
     def delete(self, db: DbSession, atbd: Atbds, version: AtbdVersions):
         """

--- a/app/crud/versions.py
+++ b/app/crud/versions.py
@@ -1,23 +1,25 @@
 """CRUD operations for ATBD Versions."""
 
+from typing import Union
+
 from sqlalchemy.orm import Session
 
 from app.crud.base import CRUDBase
 from app.db.db_session import DbSession
 from app.db.models import Atbds, AtbdVersions
-from app.schemas.versions import Create, FullOutput, Update, LockUpdate
+from app.schemas.versions import Create, FullOutput, Update
 
 
 class CRUDVersions(CRUDBase[AtbdVersions, FullOutput, Create, Update]):
     """CRUDVersions"""
 
     def set_lock(
-        self, db: Session, *, version: AtbdVersions, obj_in: LockUpdate
+        self, db: Session, *, version: AtbdVersions, locked_by: Union[str, None]
     ):
-        """Queries the item in the DB, updates the class's attributes and
-        re-inserts into the DB."""
-        update_data = obj_in.dict(exclude_unset=True, exclude_none=False)
-        setattr(version, 'locked_by', update_data['locked_by'])
+        """Custom method used instead of CRUDBase update, which ignores
+        None type fields"""
+
+        version.locked_by = locked_by
 
         db.add(version)
         db.commit()

--- a/app/crud/versions.py
+++ b/app/crud/versions.py
@@ -20,11 +20,10 @@ class CRUDVersions(CRUDBase[AtbdVersions, FullOutput, Create, Update]):
         None type fields"""
 
         version.locked_by = locked_by
-
         db.add(version)
         db.commit()
         db.refresh(version)
-        return version
+        return {}
 
     def delete(self, db: DbSession, atbd: Atbds, version: AtbdVersions):
         """

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -124,15 +124,15 @@ class AtbdVersions(Base):
 
             for action in actions:
 
-                for key, allowed_values in actions.get("conditions", {}).items():
-                    if not getattr(self, key) in allowed_values:
-                        continue
+                permission = fastapi_permissions.Deny
 
-                permission = (
-                    fastapi_permissions.Deny
-                    if action.get("deny")
-                    else fastapi_permissions.Allow
-                )
+                if not action.get("deny") and all(
+                    [
+                        getattr(self, key) in allowed_values
+                        for key, allowed_values in action.get("conditions", {}).items()
+                    ]
+                ):
+                    permission = fastapi_permissions.Allow
 
                 if isinstance(grantee, str):
                     acl.append((permission, grantee, action["action"]))

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -110,6 +110,9 @@ class AtbdVersions(Base):
         acl = []
         for grantee, actions in acls.ATBD_VERSION_ACLS.items():
 
+            if grantee == "lock_owner":
+                grantee = f"user:{self.locked_by}"
+
             if grantee == "owner":
                 grantee = f"user:{self.owner}"
 
@@ -121,8 +124,9 @@ class AtbdVersions(Base):
 
             for action in actions:
 
-                if action.get("status") and self.status not in action["status"]:
-                    continue
+                for key, allowed_values in actions.get("conditions", {}).items():
+                    if not getattr(self, key) in allowed_values:
+                        continue
 
                 permission = (
                     fastapi_permissions.Deny

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -89,6 +89,7 @@ class AtbdVersions(Base):
     reviewers = Column(postgresql.ARRAY(postgresql.JSONB), server_default="{{}}")
     journal_status = Column(String())
     keywords = Column(postgresql.ARRAY(postgresql.JSONB), server_default="{{}}")
+    locked_by = Column(String(), nullable=True)
 
     def __repr__(self):
         """String representation"""

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -109,7 +109,6 @@ class AtbdVersions(Base):
 
         acl = []
         for grantee, actions in acls.ATBD_VERSION_ACLS.items():
-
             if grantee == "lock_owner":
                 grantee = f"user:{self.locked_by}"
 

--- a/app/main.py
+++ b/app/main.py
@@ -26,7 +26,7 @@ if config.BACKEND_CORS_ORIGINS:
         CORSMiddleware,
         allow_origins=origins,
         allow_credentials=True,
-        allow_methods=["HEAD", "GET", "POST", "DELETE"],
+        allow_methods=["HEAD", "GET", "POST", "PUT", "DELETE"],
         allow_headers=["*"],
     )
 

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,8 @@
 from app import config
 from app.api.v2.api import api_router
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
 
 from starlette.middleware.cors import CORSMiddleware
 from starlette.middleware.gzip import GZipMiddleware

--- a/app/permissions.py
+++ b/app/permissions.py
@@ -27,6 +27,7 @@ def filter_atbd_versions(
             raise_exception=False,
         )
     ]
+
     if not versions:
         if not raise_exception:
             return None

--- a/app/permissions.py
+++ b/app/permissions.py
@@ -8,7 +8,9 @@ import fastapi_permissions
 from fastapi import HTTPException
 
 
-def filter_atbd_versions(principals: List[str], atbd: Atbds, error=True) -> Atbds:
+def filter_atbd_versions(
+    principals: List[str], atbd: Atbds, raise_exception=True
+) -> Atbds:
     """
     Applies a permission check to a list of ATBDs, returning only the versions
     that the user is allowed to see. If an ATBD has NO versions that the user is
@@ -19,14 +21,17 @@ def filter_atbd_versions(principals: List[str], atbd: Atbds, error=True) -> Atbd
         version
         for version in atbd.versions
         if check_permissions(
-            principals=principals, action="view", acl=version.__acl__(), error=False
+            principals=principals,
+            action="view",
+            acl=version.__acl__(),
+            raise_exception=False,
         )
     ]
     if not versions:
-        if error:
-            raise HTTPException(status_code=404, detail="No atbds found")
-        else:
+        if not raise_exception:
             return None
+        raise HTTPException(status_code=404, detail="No atbds found")
+
     atbd.versions = versions
     return atbd
 
@@ -50,7 +55,7 @@ def check_atbd_permissions(
             principals=principals,
             action=action,
             acl=[(fastapi_permissions.Allow, "role:contributor", "create_atbd")],
-            error=False,
+            raise_exception=False,
         ):
             raise HTTPException(
                 status_code=403, detail="User is not allowed to create a new ATBD"
@@ -59,7 +64,10 @@ def check_atbd_permissions(
 
     permissions = [
         check_permissions(
-            principals=principals, action=action, acl=version.__acl__(), error=False
+            principals=principals,
+            action=action,
+            acl=version.__acl__(),
+            raise_exception=False,
         )
         for version in atbd.versions
     ]
@@ -76,17 +84,18 @@ def check_atbd_permissions(
 
 
 def check_permissions(
-    principals: List[str], action: str, acl: List[Tuple], error=True
+    principals: List[str], action: str, acl: List[Tuple], raise_exception=True
 ) -> bool:
     """Applies permission check for the requested action. Can be configured to either
     raise an exception or return a boolean"""
     if not fastapi_permissions.has_permission(principals, action, acl):
-        if error:
-            action_name = " ".join([x.capitalize() for x in action.split("_")])
-            raise HTTPException(
-                status_code=403,
-                detail=f"{action_name} for ATBD Version is not allowed",
-            )
-        else:
+        # don't raise an exception, return bool
+        if not raise_exception:
             return False
+
+        action_name = " ".join([x.capitalize() for x in action.split("_")])
+        raise HTTPException(
+            status_code=403,
+            detail=f"{action_name} for ATBD Version is not allowed",
+        )
     return True

--- a/app/schemas/users.py
+++ b/app/schemas/users.py
@@ -41,12 +41,19 @@ class CognitoUser(AnonymousUser):
     def _unpack_attributes(cls, values):
         # list_users_in_group response model has user attributes
         # under `Attributes` whereas the admin_get_user response model
-        # lists user attributes under `UserAttributes`. TODO: check
-        # which key contains the user attributes and handle accordingly
-        if "Attributes" not in values:
+        # lists user attributes under `UserAttributes`. The following
+        # line searches through the provided values, searching for
+        # either the `Attribuets` or the `UserAttributes` key to then
+        # use to reformat the values of the data model.
+
+        user_attributes_key = next(
+            (k for k in values.keys() if k in ["Attributes", "UserAttributes"]), None
+        )
+
+        if not user_attributes_key:
             return values
 
-        for attribute in values["Attributes"]:
+        for attribute in values[user_attributes_key]:
             if attribute["Name"] in [
                 "email",
                 "sub",

--- a/app/schemas/users.py
+++ b/app/schemas/users.py
@@ -39,6 +39,10 @@ class CognitoUser(AnonymousUser):
 
     @root_validator(pre=True)
     def _unpack_attributes(cls, values):
+        # list_users_in_group response model has user attributes
+        # under `Attributes` whereas the admin_get_user response model
+        # lists user attributes under `UserAttributes`. TODO: check
+        # which key contains the user attributes and handle accordingly
         if "Attributes" not in values:
             return values
 

--- a/app/schemas/versions.py
+++ b/app/schemas/versions.py
@@ -323,7 +323,6 @@ class Update(BaseModel):
     authors: Optional[List[str]]
     reviewers: Optional[List[str]]
     journal_status: Optional[JournalStatusEnum]
-    locked_by: Optional[str]
 
 
 class AdminUpdate(Update):
@@ -339,3 +338,16 @@ class AdminUpdate(Update):
     # since from the API side, each reviewer should have
     # a review status associated with their user sub
     reviewers: Optional[List[Dict[str, str]]]  # type: ignore
+
+
+class LockOwner(BaseModel):
+    """Lock owner model"""
+
+    email: str
+    preferred_username: str
+
+
+class LockOutput(BaseModel):
+    """Output for lock owner query"""
+
+    locked_by: LockOwner

--- a/app/schemas/versions.py
+++ b/app/schemas/versions.py
@@ -341,4 +341,4 @@ class AdminUpdate(Update):
 
 
 class LockUpdate(BaseModel):
-    locked_by: str
+    locked_by: Union[str, None]

--- a/app/schemas/versions.py
+++ b/app/schemas/versions.py
@@ -338,3 +338,7 @@ class AdminUpdate(Update):
     # since from the API side, each reviewer should have
     # a review status associated with their user sub
     reviewers: Optional[List[Dict[str, str]]]  # type: ignore
+
+
+class LockUpdate(BaseModel):
+    locked_by: str

--- a/app/schemas/versions.py
+++ b/app/schemas/versions.py
@@ -323,6 +323,7 @@ class Update(BaseModel):
     authors: Optional[List[str]]
     reviewers: Optional[List[str]]
     journal_status: Optional[JournalStatusEnum]
+    locked_by: Optional[str]
 
 
 class AdminUpdate(Update):
@@ -338,7 +339,3 @@ class AdminUpdate(Update):
     # since from the API side, each reviewer should have
     # a review status associated with their user sub
     reviewers: Optional[List[Dict[str, str]]]  # type: ignore
-
-
-class LockUpdate(BaseModel):
-    locked_by: Union[str, None]

--- a/app/users/cognito.py
+++ b/app/users/cognito.py
@@ -89,7 +89,7 @@ def update_user_info(
                 principals=principals,
                 action=f"view_{contributor_type}",
                 acl=version_acl,
-                error=False,
+                raise_exception=False,
             ):
                 setattr(data_model, attr, app_users[user_sub].dict(by_alias=True))
             else:
@@ -151,7 +151,10 @@ def update_version_contributor_info(principals: List[str], version: AtbdVersions
     )
 
     if check_permissions(
-        principals=principals, action="view_owner", acl=version_acl, error=False
+        principals=principals,
+        action="view_owner",
+        acl=version_acl,
+        raise_exception=False,
     ):
         version.owner = app_users[version.owner].dict(by_alias=True)
 
@@ -161,7 +164,10 @@ def update_version_contributor_info(principals: List[str], version: AtbdVersions
         )
 
     if check_permissions(
-        principals=principals, action="view_authors", acl=version_acl, error=False
+        principals=principals,
+        action="view_authors",
+        acl=version_acl,
+        raise_exception=False,
     ):
 
         version.authors = [
@@ -176,7 +182,10 @@ def update_version_contributor_info(principals: List[str], version: AtbdVersions
         ]
 
     if check_permissions(
-        principals=principals, action="view_reviewers", acl=version_acl, error=False
+        principals=principals,
+        action="view_reviewers",
+        acl=version_acl,
+        raise_exception=False,
     ):
 
         version.reviewers = [
@@ -259,12 +268,10 @@ def list_cognito_users(groups="curator,contributor"):
 
 
 def get_cognito_user(sub: str):
+    """Returns a single user from cognito"""
     client = cognito_client()
-    user = client.admin_get_user(
-        UserPoolId=config.USER_POOL_ID,
-        Username=sub
-    )
-    return user
+    user = client.admin_get_user(UserPoolId=config.USER_POOL_ID, Username=sub)
+    return users.CognitoUser(user)
 
 
 def process_users_input(

--- a/app/users/cognito.py
+++ b/app/users/cognito.py
@@ -20,7 +20,6 @@ from fastapi import BackgroundTasks, Depends
 def get_active_user_principals(user: users.User = Depends(get_user)) -> List[str]:
     """Returns the principals for a user, to be used when validating permissions
     to perform certain actions or requests"""
-
     principals = [permissions.Everyone]
     if user:
         principals.extend([permissions.Authenticated, f"user:{user.sub}"])
@@ -271,7 +270,9 @@ def get_cognito_user(sub: str):
     """Returns a single user from cognito"""
     client = cognito_client()
     user = client.admin_get_user(UserPoolId=config.USER_POOL_ID, Username=sub)
-    return users.CognitoUser(user)
+    print("USER: ", user)
+    print("KEYS: ", user.keys())
+    return users.CognitoUser(**user)
 
 
 def process_users_input(

--- a/app/users/cognito.py
+++ b/app/users/cognito.py
@@ -270,8 +270,6 @@ def get_cognito_user(sub: str):
     """Returns a single user from cognito"""
     client = cognito_client()
     user = client.admin_get_user(UserPoolId=config.USER_POOL_ID, Username=sub)
-    print("USER: ", user)
-    print("KEYS: ", user.keys())
     return users.CognitoUser(**user)
 
 

--- a/app/users/cognito.py
+++ b/app/users/cognito.py
@@ -258,6 +258,15 @@ def list_cognito_users(groups="curator,contributor"):
     return (app_users, str(uuid4()))
 
 
+def get_cognito_user(sub: str):
+    client = cognito_client()
+    user = client.admin_get_user(
+        UserPoolId=config.USER_POOL_ID,
+        Username=sub
+    )
+    return user
+
+
 def process_users_input(
     version_input: versions.Update,
     atbd_version: AtbdVersions,

--- a/db/deploy/version_lock.sql
+++ b/db/deploy/version_lock.sql
@@ -1,0 +1,9 @@
+-- Deploy nasa-apt:version_lock to pg
+-- requires: tables
+
+BEGIN;
+
+ALTER TABLE apt.atbd_versions
+    ADD COLUMN "locked_by" VARCHAR(1024);
+
+COMMIT;

--- a/db/revert/version_lock.sql
+++ b/db/revert/version_lock.sql
@@ -1,0 +1,8 @@
+-- Revert nasa-apt:version_lock from pg
+
+BEGIN;
+
+ALTER TABLE apt.atbd_versions
+    DROP COLUMN "locked_by";
+
+COMMIT;

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -21,3 +21,4 @@ drop_contact_roles [contact_roles] 2021-11-15T19:16:45Z Leo Thomas <leo@MacBook-
 @v2.1.0-beta 2021-12-03T15:28:49Z Leo Thomas <leo@MacBook-Pro.lan> # Tag v2.1.0-beta release 2021_12_03
 
 summary_abstract_rich_text 2022-04-26T15:17:32Z Leo Thomas <leo@MacBook-Pro-2.local> # Convert the abstract and plain_summary fields of the document object to rich text objects
+version_lock [tables] 2022-06-01T06:57:35Z Oliver Roick <oroick@192-168-1-106.tpgi.com.au> # Add locked_by field to atbd_versions

--- a/db/verify/version_lock.sql
+++ b/db/verify/version_lock.sql
@@ -1,0 +1,7 @@
+-- Verify nasa-apt:version_lock on pg
+
+BEGIN;
+
+-- XXX Add verifications here.
+
+ROLLBACK;


### PR DESCRIPTION
### Features: 
- Adds a new "user" type: `lock_owner` who is the only users granted permission to update an ATBD Version
- Grants `author` and `owner` users the permission to secure the lock
- Adds a `lock` endpoint with `PUT` and `DELETE` capacity for securing and releasing the lock
    - `PUT` lock first validates that no one already owns the lock (or that the requesting user is the lock owner)
    - `DELETE` lock fist validates that the requesting owner is the lock owner (or that the lock is empty)
    - adds an `override: bool` flag to allow a user other than the lock owner to secure the lock (in case the lock owner does not release the lock after updating a document)

### Improvements: 
- Generalizes the framework for generating ACL (access control list) for ATBD versions to enforce _any_ field from the ATBD Version to be equal to one of a list of possible values
- Update syntax in the `check_permissions` function to clarify wether or not the function will raise an exception if the requested action is not allowed
- Implements a `set_lock` function in the CRUD class for ATBD Versions, since the Update function from the base CRUD class ignore `None` type values, whereas we need the ability to set the lock to `None` in order to release it
- Adds functionality in the schema User class, which checks if the provided object contains user info under the `UserAttributes` key (as is the case in the `cognito.get_user` method) or the `Attributes` key (as is the case in the `cognito.list_users_in_group` method, and handle accordingly

### Collaborators: 
@oliverroick 
 