### PR TITLE
Thread notifications

### DIFF
--- a/app/api/v2/threads.py
+++ b/app/api/v2/threads.py
@@ -191,7 +191,10 @@ def create_thread(
         atbd_title=atbd.title,
         atbd_id=atbd.id,
         user=user,
-        data={"section": thread.section},
+        data={
+            "section": thread.section,
+            "notify": thread.notify
+        },
     )
 
     return thread
@@ -295,7 +298,10 @@ def create_comment(
         atbd_title=atbd.title,
         atbd_id=atbd.id,
         user=user,
-        data={"section": thread.section},
+        data={
+            "section": thread.section,
+            "notify": comment_input.notify
+        },
     )
 
     return comment

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -303,6 +303,7 @@ class Threads(Base):
     created_at = Column(types.DateTime, server_default=utcnow(), nullable=False)
     last_updated_by = Column(String(), nullable=False)
     last_updated_at = Column(types.DateTime, server_default=utcnow(), nullable=False)
+    notify = Column(types.ARRAY(String), nullable=True)
 
     comments = relationship(
         "Comments",

--- a/app/email/notifications.py
+++ b/app/email/notifications.py
@@ -37,32 +37,44 @@ def notify_atbd_version_contributors(
     """
     app_users, _ = cognito.list_cognito_users()
 
-    user_notifications = [
-        UserNotification(
-            **app_users[atbd_version.owner].dict(),
-            notification=notification,
-            data=data,
-        )  # type: ignore
-    ]
+    user_notifications = []
 
-    user_notifications.extend(
-        [
+    if (len(data['notify']) > 0):
+        user_notifications = [
             UserNotification(
-                **app_users[author].dict(), notification=notification, data=data  # type: ignore
+                **app_users[user_sub].dict(),
+                notification=notification,
+                data=data,
             )
-            for author in atbd_version.authors
+            for user_sub in data['notify']
         ]
-    )
-    user_notifications.extend(
-        [
+    else:
+        user_notifications = [
             UserNotification(
-                **app_users[reviewer["sub"]].dict(),
+                **app_users[atbd_version.owner].dict(),
                 notification=notification,
                 data=data,
             )  # type: ignore
-            for reviewer in atbd_version.reviewers
         ]
-    )
+
+        user_notifications.extend(
+            [
+                UserNotification(
+                    **app_users[author].dict(), notification=notification, data=data  # type: ignore
+                )
+                for author in atbd_version.authors
+            ]
+        )
+        user_notifications.extend(
+            [
+                UserNotification(
+                    **app_users[reviewer["sub"]].dict(),
+                    notification=notification,
+                    data=data,
+                )  # type: ignore
+                for reviewer in atbd_version.reviewers
+            ]
+        )
     return notify_users(
         user_notifications=user_notifications,
         atbd_title=atbd_title,

--- a/app/schemas/comments.py
+++ b/app/schemas/comments.py
@@ -1,6 +1,6 @@
 """Schemas for Comments Model"""
 from datetime import datetime
-from typing import Union
+from typing import List, Union
 
 from pydantic import BaseModel
 

--- a/app/schemas/comments.py
+++ b/app/schemas/comments.py
@@ -1,6 +1,6 @@
 """Schemas for Comments Model"""
 from datetime import datetime
-from typing import List, Union
+from typing import Optional, List, Union
 
 from pydantic import BaseModel
 
@@ -11,11 +11,13 @@ class Create(BaseModel):
     """Create first comment"""
 
     body: str
+    notify: Optional[List[str]]
 
 
-class AdminCreate(Create):
+class AdminCreate(BaseModel):
     """Create comment"""
 
+    body: str
     thread_id: int
     created_by: str
     last_updated_by: str

--- a/app/schemas/threads.py
+++ b/app/schemas/threads.py
@@ -69,7 +69,7 @@ class Output(BaseModel):
     last_updated_by: Union[users.CognitoUser, users.AnonymousUser]
     last_updated_at: datetime
     comment_count: Optional[int]
-    notify: List[str]
+    notify: Optional[List[str]]
 
     class Config:
         """Config."""

--- a/app/schemas/threads.py
+++ b/app/schemas/threads.py
@@ -26,6 +26,7 @@ class AdminCreate(BaseModel):
     section: str
     created_by: str
     last_updated_by: str
+    notify: Optional[List[str]]
 
 
 class Create(BaseModel):
@@ -36,6 +37,7 @@ class Create(BaseModel):
     version: str
     section: str
     major: Optional[int]
+    notify: Optional[List[str]]
 
     @validator("major", always=True)
     def _extract_major(cls, v, values) -> int:
@@ -67,6 +69,7 @@ class Output(BaseModel):
     last_updated_by: Union[users.CognitoUser, users.AnonymousUser]
     last_updated_at: datetime
     comment_count: Optional[int]
+    notify: List[str]
 
     class Config:
         """Config."""

--- a/db/deploy/threads_notify.sql
+++ b/db/deploy/threads_notify.sql
@@ -1,0 +1,9 @@
+-- Deploy nasa-apt:threads_notify to pg
+-- requires: threads
+
+BEGIN;
+
+ALTER TABLE apt.threads
+    ADD COLUMN "notify" text[];
+
+COMMIT;

--- a/db/revert/threads_notify.sql
+++ b/db/revert/threads_notify.sql
@@ -1,0 +1,8 @@
+-- Revert nasa-apt:threads_notify from pg
+
+BEGIN;
+
+ALTER TABLE apt.threads
+    DROP COLUMN "notify";
+
+COMMIT;

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -23,3 +23,5 @@ drop_contact_roles [contact_roles] 2021-11-15T19:16:45Z Leo Thomas <leo@MacBook-
 summary_abstract_rich_text 2022-04-26T15:17:32Z Leo Thomas <leo@MacBook-Pro-2.local> # Convert the abstract and plain_summary fields of the document object to rich text objects
 version_lock [tables] 2022-06-01T06:57:35Z Oliver Roick <oroick@192-168-1-106.tpgi.com.au> # Add locked_by field to atbd_versions
 @v2.4.0-beta 2022-06-29T16:19:41Z Leo Thomas <leo@MacBook-Pro-2> # Tag v2.4.0-beta release 2022_06_25
+
+threads_notify [threads] 2022-07-27T07:06:50Z Oliver Roick <oroick@192-168-1-106.tpgi.com.au> # Add notify field to threads

--- a/db/verify/threads_notify.sql
+++ b/db/verify/threads_notify.sql
@@ -1,0 +1,7 @@
+-- Verify nasa-apt:threads_notify on pg
+
+BEGIN;
+
+-- XXX Add verifications here.
+
+ROLLBACK;


### PR DESCRIPTION
Contributes front-end implementation for https://github.com/NASA-IMPACT/nasa-apt/issues/456

- Adds new field `notify` to table `apt.threads`; extends models accordingly
- Extends APIs to create threads and comments, so `notify` is accepted and written to the database
- Extends API for getting threads, so the notify field is returned

Test this together with https://github.com/NASA-IMPACT/nasa-apt/pull/544
