### PR TITLE
Allow update journal publication status for all ATDB status

### DIFF
--- a/app/acls.py
+++ b/app/acls.py
@@ -46,12 +46,7 @@ ATBD_VERSION_ACLS: Dict = {
         },
         {"action": "create_new_version", "conditions": {"status": ["PUBLISHED"]}},
         {"action": "bump_minor_version", "conditions": {"status": ["PUBLISHED"]}},
-        {
-            "action": "update_journal_publication_status",
-            "conditions": {
-                "status": ["PUBLICATION", "PUBLISHED"],
-            },
-        },
+        {"action": "update_journal_publication_status"},
         {"action": "update_journal_status"},
         {"action": "join_reviewers", "deny": True},
         {"action": "join_authors", "deny": True},
@@ -129,12 +124,7 @@ ATBD_VERSION_ACLS: Dict = {
         {"action": "override_release_lock"},
         {"action": "create_new_version", "conditions": {"status": ["PUBLISHED"]}},
         {"action": "bump_minor_version", "conditions": {"status": ["PUBLISHED"]}},
-        {
-            "action": "update_journal_publication_status",
-            "conditions": {
-                "status": ["PUBLICATION", "PUBLISHED"],
-            },
-        },
+        {"action": "update_journal_publication_status"},
         {"action": "update_journal_status"},
         {"action": "view_owner"},
         {"action": "view_authors"},


### PR DESCRIPTION
Contributes to https://github.com/NASA-IMPACT/nasa-apt/issues/480

Updating the journal publication status was only possible of the ATBD was in publication or published. We want to enable that status can be set independently from the ATDB status, so removing the status constraints from the permissions ACLs. 