### PR TITLE
Remove in-publication status from ATBD workflow

### DIFF
--- a/app/acls.py
+++ b/app/acls.py
@@ -23,7 +23,6 @@ ATBD_VERSION_ACLS: Dict = {
                     "CLOSED_REVIEW_REQUESTED",
                     "OPEN_REVIEW",
                     "PUBLICATION_REQUESTED",
-                    "PUBLICATION",
                     "PUBLISHED",
                 ],
             },
@@ -49,7 +48,7 @@ ATBD_VERSION_ACLS: Dict = {
         {
             "action": "update_journal_publication_status",
             "conditions": {
-                "status": ["PUBLICATION", "PUBLISHED"],
+                "status": ["PUBLISHED"],
             },
         },
         {"action": "update_journal_status"},
@@ -66,7 +65,6 @@ ATBD_VERSION_ACLS: Dict = {
         #             "CLOSED_REVIEW_REQUESTED",
         #             "OPEN_REVIEW",
         #             "PUBLICATION_REQUESTED",
-        #             "PUBLICATION",
         #             "PUBLISHED",
         #         ],
         #     },
@@ -80,7 +78,6 @@ ATBD_VERSION_ACLS: Dict = {
                     "CLOSED_REVIEW_REQUESTED",
                     "OPEN_REVIEW",
                     "PUBLICATION_REQUESTED",
-                    "PUBLICATION",
                     "PUBLISHED",
                 ],
             },
@@ -107,7 +104,6 @@ ATBD_VERSION_ACLS: Dict = {
         #             "CLOSED_REVIEW_REQUESTED",
         #             "OPEN_REVIEW",
         #             "PUBLICATION_REQUESTED",
-        #             "PUBLICATION",
         #             "PUBLISHED",
         #         ],
         #     },
@@ -121,7 +117,6 @@ ATBD_VERSION_ACLS: Dict = {
                     "CLOSED_REVIEW_REQUESTED",
                     "OPEN_REVIEW",
                     "PUBLICATION_REQUESTED",
-                    "PUBLICATION",
                     "PUBLISHED",
                 ],
             },
@@ -132,7 +127,7 @@ ATBD_VERSION_ACLS: Dict = {
         {
             "action": "update_journal_publication_status",
             "conditions": {
-                "status": ["PUBLICATION", "PUBLISHED"],
+                "status": ["PUBLISHED"],
             },
         },
         {"action": "update_journal_status"},
@@ -179,7 +174,6 @@ ATBD_VERSION_ACLS: Dict = {
                     "CLOSED_REVIEW",
                     "OPEN_REVIEW",
                     "PUBLICATION_REQUESTED",
-                    "PUBLICATION",
                     "PUBLISHED",
                 ],
             },
@@ -199,15 +193,7 @@ ATBD_VERSION_ACLS: Dict = {
             },
         },
         {"action": "open_review", "conditions": {"status": ["CLOSED_REVIEW"]}},
-        {
-            "action": "deny_publication_request",
-            "conditions": {"status": ["PUBLICATION_REQUESTED"]},
-        },
-        {
-            "action": "accept_publication_request",
-            "conditions": {"status": ["PUBLICATION_REQUESTED"]},
-        },
-        {"action": "publish", "conditions": {"status": ["PUBLICATION"]}},
+        {"action": "publish", "conditions": {"status": ["PUBLICATION_REQUESTED"]}},
     ],
     fastapi_permissions.Everyone: [
         {"action": "view", "conditions": {"status": ["PUBLISHED"]}}

--- a/app/api/v2/events.py
+++ b/app/api/v2/events.py
@@ -327,15 +327,6 @@ ACTIONS: Dict[str, Dict[str, Any]] = {
         "next_status": "OPEN_REVIEW",
         "notify": ["curators"],
     },
-    "deny_publication_request": {
-        "custom_handler": deny_request_with_comment(
-            next_status="OPEN_REVIEW", notification="deny_publication_request"
-        ),
-    },
-    "accept_publication_request": {
-        "next_status": "PUBLICATION",
-        "notify": ["owner", "authors", "reviewers"],
-    },
     "publish": {"custom_handler": publish_handler},
     "bump_minor_version": {"custom_handler": bump_minor_version_handler},
     "update_review_status": {"custom_handler": update_review_status_handler},

--- a/app/email/email_templates.json
+++ b/app/email/email_templates.json
@@ -55,14 +55,6 @@
         "subject": "Publication request cancelled",
         "content": "<p>Hi $preferred_username,</p> <p>$app_user has removed their request for publication of the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>.</p><p>Sincerely,</p><p>The APT Team</p>"
     },
-    "deny_publication_request": {
-        "subject": "Publication request denied",
-        "content": "<p>Hi $preferred_username,</p> <p>$app_user ($role) has denied the request for publication of the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a> with this note: $comment.</p><p>Sincerely,</p><p>The APT Team</p>"
-    },
-    "accept_publication_request": {
-        "subject": "Publication request accepted",
-        "content": "<p>Hi $preferred_username,</p> <p>$app_user ($role) has accepted the request for publication of the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>!</p><p>Sincerely,</p><p>The APT Team</p>"
-    },
     "publish": {
         "subject": "Atbd version published",
         "content": "<p>Hi $preferred_username,</p> <p>$app_user ($role) has published the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>!</p><p>Sincerely,</p><p>The APT Team</p>"


### PR DESCRIPTION
Backend changes for https://github.com/NASA-IMPACT/nasa-apt/issues/480

- Removes the in-publication status (`PUBLICATION`)
- Removes corresponding permissions, events and email templates
- Changes permission ACLs so ATBDs can be moved from publication requested to public (`PUBLISHED`)
