### PR TITLE
add Flake8 ignore code to pre-commit, linter unable to recognize modu…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,8 @@ repos:
               # E501 let black handle all line length decisions
               # W503 black conflicts with "line break before operator" rule
               # E203 black conflicts with "whitespace before ':'" rule
-              "--ignore=E501,W503,E203",
+              # F401 module imported but unused. Flake8 may have issues recognizing a import's use in nested infrastructure code when deploying multiple stacks
+              "--ignore=E501,W503,E203,F401",
             ]
   
     - repo: https://github.com/PyCQA/pydocstyle


### PR DESCRIPTION
Flake8 may have problems recognizing module import's usage in infrastructure code. The issue seems to come up especially when multi-stacks are deployed or when infrastructure code is nested within a codebase. See [Flake8 errors codes](https://flake8.pycqa.org/en/latest/user/error-codes.html) for more info, and [Flake8 full list of flags/ignore flag](https://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-ignore)