### PR TITLE
Update AWS cdk version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
   #         pip install --upgrade pip setuptools wheel 
   #         pip install -e .[deploy] --no-binary xmlsec
   #     - name: Install CDK
-  #       run: npm install -g aws-cdk
+  #       run: npm install -g aws-cdk@2.34.2
   #     - name: Bootstrap CDK 
   #       run: cdk bootstrap
   #     - name: Deploy stack


### PR DESCRIPTION
Updating the aws cdk versions in deploy-stage ci scripts. Reason: Transitioning elasticSearch to AWS openSearch

