### PR TITLE
update subnet type deprecation source: https://docs.aws.amazon.com/cd…

### DIFF
--- a/stack/app.py
+++ b/stack/app.py
@@ -68,7 +68,7 @@ class nasaAPTLambdaStack(core.Stack):
                     ),
                     ec2.SubnetConfiguration(
                         name="private-subnet",
-                        subnet_type=ec2.SubnetType.PRIVATE,
+                        subnet_type=ec2.SubnetType.PRIVATE_WITH_NAT,
                         cidr_mask=28,
                     ),
                 ],


### PR DESCRIPTION
The Subnet type in our CDK infrastructure code has been deprecated.
The warning blocks deployment to staging.
Merging in with the new/correct subnet type `PRIVATE_WITH_NAT` from CDK warnings.