### PR TITLE
update `new_thread_created` text, fixed typo in `new_comment_created`

### DIFF
--- a/app/email/email_templates.json
+++ b/app/email/email_templates.json
@@ -70,5 +70,9 @@
   "thread_closed": {
     "subject": "Thread closed",
     "content": "<p>Hi $preferred_username,</p> <p>$app_user ($role) has closed a thread in the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>, section: $section. </p><p>Sincerely,</p><p>The APT Team</p>"
+  },
+  "thread_reopened": {
+    "subject": "Thread reopened",
+    "content": "<p>Hi $preferred_username,</p> <p>$app_user ($role) has reopened a thread in the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>, section: $section. </p><p>Sincerely,</p><p>The APT Team</p>"
   }
 }

--- a/app/email/email_templates.json
+++ b/app/email/email_templates.json
@@ -69,10 +69,10 @@
   },
   "thread_closed": {
     "subject": "Thread closed",
-    "content": "<p>Hi $preferred_username,</p> <p>$app_user ($role) has closed a thread in the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>, section: $section. </p><p>Sincerely,</p><p>The APT Team</p>"
+    "content": "<p>A comment has been resolved on ATBD <a href=\"$atbd_version_link\">$atbd_title</a> in APT by $app_user ($role).</p><p>Sincerely,</p><p>The APT Team</p>"
   },
   "thread_reopened": {
     "subject": "Thread reopened",
-    "content": "<p>Hi $preferred_username,</p> <p>$app_user ($role) has reopened a thread in the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>, section: $section. </p><p>Sincerely,</p><p>The APT Team</p>"
+    "content": "<p>A comment has been reopened on ATBD <a href=\"$atbd_version_link\">$atbd_title</a> in APT by $app_user ($role).</p><p>Sincerely,</p><p>The APT Team</p>"
   }
 }

--- a/app/email/email_templates.json
+++ b/app/email/email_templates.json
@@ -1,74 +1,74 @@
 {
-    "added_as_reviewer": {
-        "subject": "Your review has been requested",
-        "content": "<p>Hi $preferred_username,</p> <p>$app_user ($role) has requested your review on the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>.</p><p>Sincerely,</p><p>The APT Team</p>"
-    },
-    "added_as_author": {
-        "subject": "You have been added as an author",
-        "content": "<p>Hi $preferred_username,</p> <p>$app_user ($role) has added you as a collaborating author on the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>.</p><p>Sincerely,</p><p>The APT Team</p>"
-    },
-    "added_as_owner": {
-        "subject": "You have been given ownership",
-        "content": "<p>Hi $preferred_username,</p> <p>$app_user ($role) has transferred you ownership of the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>.</p><p>Sincerely,</p><p>The APT Team</p>"
-    },
-    "ownership_revoked": {
-        "subject": "Your ownership has been revoked",
-        "content": "<p>Hi $preferred_username,</p> <p>$app_user ($role) has transferred your ownership of the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a> to $transferred_to. You have been added as an author of the document.</p><p>Sincerely,</p><p>The APT Team</p>"
-    },
-    "new_thread_created": {
-        "subject": "A new thread has been created",
-        "content": "<p>Hi $preferred_username,</p> <p>$app_user has created a new thread in document: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>, section: $section.</p><p>Sincerely,</p><p>The APT Team</p>"
-    },
-    "new_comment_created": {
-        "subject": "A new comment has been added",
-        "content": "<p>Hi $preferred_username,</p> <p>$app_user has added a new commented to a thread in document: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>, section: $section.</p><p>Sincerely,</p><p>The APT Team</p>"
-    },
-    "comment_mention": {
-        "subject": "You have been mentioned in a comment on ATBD $atbd_title in APT",
-        "content": "<p>You have been mentioned in a comment on ATBD <a href=\"$atbd_version_link\">$atbd_title</a> in APT.</p><p>Sincerely,</p><p>The APT Team</p>"
-    },
-    "request_closed_review": {
-        "subject": "Closed review requested",
-        "content": "<p>Hi $preferred_username,</p> <p>$app_user has marked the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a> as ready for closed review.</p><p>Sincerely,</p><p>The APT Team</p>"
-    },
-    "cancel_closed_review_request": {
-        "subject": "Closed review request cancelled",
-        "content": "<p>Hi $preferred_username,</p> <p>$app_user has removed their request for closed review of the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>.</p><p>Sincerely,</p><p>The APT Team</p>"
-    },
-    "deny_closed_review_request": {
-        "subject": "Closed review request denied",
-        "content": "<p>Hi $preferred_username,</p> <p>$app_user ($role) has denied the request for closed review of the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a> with this note: $comment.</p><p>Sincerely,</p><p>The APT Team</p>"
-    },
-    "accept_closed_review_request": {
-        "subject": "Closed review request accepted",
-        "content": "<p>Hi $preferred_username,</p> <p>$app_user ($role) has accepted the request for closed review of the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>.</p><p>Sincerely,</p><p>The APT Team</p>"
-    },
-    "all_reviews_done": {
-        "subject": "All reviews are finished",
-        "content": "<p>Hi $preferred_username,</p> <p>All reviewers of the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a> have marked their review as DONE. It is now ready to be considered for the open review stage.</p><p>Sincerely,</p><p>The APT Team</p>"
-    },
-    "open_review": {
-        "subject": "ATBD version transitioned to open review",
-        "content": "<p>Hi $preferred_username,</p> <p>$app_user ($role) has transitioned the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a> to the open review stage.</p><p>Sincerely,</p><p>The APT Team</p>"
-    },
-    "request_publication": {
-        "subject": "Publication requested",
-        "content": "<p>Hi $preferred_username,</p> <p>$app_user has requested publication of the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>.</p><p>Sincerely,</p><p>The APT Team</p>"
-    },
-    "cancel_publication_request": {
-        "subject": "Publication request cancelled",
-        "content": "<p>Hi $preferred_username,</p> <p>$app_user has removed their request for publication of the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>.</p><p>Sincerely,</p><p>The APT Team</p>"
-    },
-    "publish": {
-        "subject": "Atbd version published",
-        "content": "<p>Hi $preferred_username,</p> <p>$app_user ($role) has published the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>!</p><p>Sincerely,</p><p>The APT Team</p>"
-    },
-    "bump_minor_version": {
-        "subject": "Atbd minor version number bumped",
-        "content": "<p>Hi $preferred_username,</p> <p>$app_user ($role) has bumped the minor vesion number of the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>!</p><p>Sincerely,</p><p>The APT Team</p>"
-    },
-    "thread_closed": {
-        "subject": "Thread closed",
-        "content": "<p>Hi $preferred_username,</p> <p>$app_user ($role) has closed a thread in the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>, section: $section. </p><p>Sincerely,</p><p>The APT Team</p>"
-    }
+  "added_as_reviewer": {
+    "subject": "Your review has been requested",
+    "content": "<p>Hi $preferred_username,</p> <p>$app_user ($role) has requested your review on the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>.</p><p>Sincerely,</p><p>The APT Team</p>"
+  },
+  "added_as_author": {
+    "subject": "You have been added as an author",
+    "content": "<p>Hi $preferred_username,</p> <p>$app_user ($role) has added you as a collaborating author on the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>.</p><p>Sincerely,</p><p>The APT Team</p>"
+  },
+  "added_as_owner": {
+    "subject": "You have been given ownership",
+    "content": "<p>Hi $preferred_username,</p> <p>$app_user ($role) has transferred you ownership of the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>.</p><p>Sincerely,</p><p>The APT Team</p>"
+  },
+  "ownership_revoked": {
+    "subject": "Your ownership has been revoked",
+    "content": "<p>Hi $preferred_username,</p> <p>$app_user ($role) has transferred your ownership of the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a> to $transferred_to. You have been added as an author of the document.</p><p>Sincerely,</p><p>The APT Team</p>"
+  },
+  "new_thread_created": {
+    "subject": "A new thread has been created",
+    "content": "<p>Hi $preferred_username,</p> <p>$app_user has added a new comment to an existing thread in the ATBD document: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>, section: $section.</p><p>Sincerely,</p><p>The APT Team</p>"
+  },
+  "new_comment_created": {
+    "subject": "A new comment has been added",
+    "content": "<p>Hi $preferred_username,</p> <p>$app_user has added a new comment to a thread in document: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>, section: $section.</p><p>Sincerely,</p><p>The APT Team</p>"
+  },
+  "comment_mention": {
+    "subject": "You have been mentioned in a comment on ATBD $atbd_title in APT",
+    "content": "<p>You have been mentioned in a comment on ATBD <a href=\"$atbd_version_link\">$atbd_title</a> in APT.</p><p>Sincerely,</p><p>The APT Team</p>"
+  },
+  "request_closed_review": {
+    "subject": "Closed review requested",
+    "content": "<p>Hi $preferred_username,</p> <p>$app_user has marked the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a> as ready for closed review.</p><p>Sincerely,</p><p>The APT Team</p>"
+  },
+  "cancel_closed_review_request": {
+    "subject": "Closed review request cancelled",
+    "content": "<p>Hi $preferred_username,</p> <p>$app_user has removed their request for closed review of the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>.</p><p>Sincerely,</p><p>The APT Team</p>"
+  },
+  "deny_closed_review_request": {
+    "subject": "Closed review request denied",
+    "content": "<p>Hi $preferred_username,</p> <p>$app_user ($role) has denied the request for closed review of the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a> with this note: $comment.</p><p>Sincerely,</p><p>The APT Team</p>"
+  },
+  "accept_closed_review_request": {
+    "subject": "Closed review request accepted",
+    "content": "<p>Hi $preferred_username,</p> <p>$app_user ($role) has accepted the request for closed review of the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>.</p><p>Sincerely,</p><p>The APT Team</p>"
+  },
+  "all_reviews_done": {
+    "subject": "All reviews are finished",
+    "content": "<p>Hi $preferred_username,</p> <p>All reviewers of the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a> have marked their review as DONE. It is now ready to be considered for the open review stage.</p><p>Sincerely,</p><p>The APT Team</p>"
+  },
+  "open_review": {
+    "subject": "ATBD version transitioned to open review",
+    "content": "<p>Hi $preferred_username,</p> <p>$app_user ($role) has transitioned the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a> to the open review stage.</p><p>Sincerely,</p><p>The APT Team</p>"
+  },
+  "request_publication": {
+    "subject": "Publication requested",
+    "content": "<p>Hi $preferred_username,</p> <p>$app_user has requested publication of the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>.</p><p>Sincerely,</p><p>The APT Team</p>"
+  },
+  "cancel_publication_request": {
+    "subject": "Publication request cancelled",
+    "content": "<p>Hi $preferred_username,</p> <p>$app_user has removed their request for publication of the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>.</p><p>Sincerely,</p><p>The APT Team</p>"
+  },
+  "publish": {
+    "subject": "Atbd version published",
+    "content": "<p>Hi $preferred_username,</p> <p>$app_user ($role) has published the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>!</p><p>Sincerely,</p><p>The APT Team</p>"
+  },
+  "bump_minor_version": {
+    "subject": "Atbd minor version number bumped",
+    "content": "<p>Hi $preferred_username,</p> <p>$app_user ($role) has bumped the minor vesion number of the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>!</p><p>Sincerely,</p><p>The APT Team</p>"
+  },
+  "thread_closed": {
+    "subject": "Thread closed",
+    "content": "<p>Hi $preferred_username,</p> <p>$app_user ($role) has closed a thread in the following ATBD version: <a href=\"$atbd_version_link\">$atbd_title, $atbd_version</a>, section: $section. </p><p>Sincerely,</p><p>The APT Team</p>"
+  }
 }


### PR DESCRIPTION
~⚠️ **Don't merge until #638 is merged** ⚠️~

Upstream: https://github.com/NASA-IMPACT/nasa-apt/issues/636#issuecomment-1442142744

_I think my linter made the diff seem more different than it really is_

@thenav56, could you address the other issues in the comment ☝️ (email notifications not being sent for resolving and unresolving comment threads)? More info is in [this spreadsheet](https://docs.google.com/spreadsheets/d/1EzsPAZ0dJNjreuEeCh3QlA3DIoFytadUxaydoH8xSds/edit#gid=1371486832&range=A2).
