### PR TITLE
Handle dangling users

### DIFF
--- a/app/email/notifications.py
+++ b/app/email/notifications.py
@@ -75,6 +75,7 @@ def notify_atbd_version_contributors(
                 data=data,
             )
             for user_id in recipient_user_ids_set
+            if user_id in app_users
         ],
         atbd_title=atbd_title,
         atbd_id=atbd_id,

--- a/app/schemas/users.py
+++ b/app/schemas/users.py
@@ -28,6 +28,9 @@ class AnonymousUser(BaseModel):
     """Obfuscated user contributing to an ATBD Version"""
 
     preferred_username: str
+    # Anonymous User Specific attributes with default values
+    is_anonymous: bool = True
+    cognito_groups: List[str] = Field(default=[], alias="cognito:groups")
 
 
 class CognitoUser(AnonymousUser):
@@ -36,6 +39,8 @@ class CognitoUser(AnonymousUser):
     sub: str
     email: str
     cognito_groups: List[str] = Field([], alias="cognito:groups")
+    is_dangling: bool = False
+    is_anonymous: bool = False
 
     @root_validator(pre=True)
     def _unpack_attributes(cls, values):


### PR DESCRIPTION
## Address:
- https://github.com/NASA-IMPACT/nasa-apt/issues/647

## Changes
- If a user is missing in cognito
  - Respond with fallback dangling user data https://github.com/NASA-IMPACT/nasa-apt/blob/07404e73cd1157562c7952de081eec7a6f78a8de/app/users/cognito.py#L254-L258
  - Log as a warning https://github.com/NASA-IMPACT/nasa-apt/blob/07404e73cd1157562c7952de081eec7a6f78a8de/app/users/cognito.py#L251
- Update existing log to
  - Skip: For notification
  - Throw an error if the user doesn't exist in Cognito anymore: If a non-existing user_sub is provided for a non-nullable user_sub field.
     > NOTE: For the authenticated users, we don't check.
- **Schema update**
  - User https://github.com/NASA-IMPACT/nasa-apt/blob/07404e73cd1157562c7952de081eec7a6f78a8de/app/schemas/users.py#L42-L43
     - Added: `is_dangling`
     - Added: `is_anonymous`
  - AnonymousUser https://github.com/NASA-IMPACT/nasa-apt/blob/07404e73cd1157562c7952de081eec7a6f78a8de/app/schemas/users.py#L32-L33
     - Added: `is_anonymous`
     - Added: `cognito_groups=[]`. To avoid the client breaking