### PR TITLE
Create index atbd if not exists on opensearch client setup

### DIFF
--- a/app/api/v2/opensearch.py
+++ b/app/api/v2/opensearch.py
@@ -9,6 +9,7 @@ from requests_aws4auth import AWS4Auth
 from app.config import OPENSEARCH_PORT, OPENSEARCH_URL
 from app.logs import logger
 from app.schemas.users import User
+from app.search.opensearch import aws_auth
 from app.users.auth import get_user
 
 from fastapi import APIRouter, Depends
@@ -16,29 +17,6 @@ from fastapi import APIRouter, Depends
 REGION = os.getenv("AWS_REGION", "us-west-2")
 
 router = APIRouter()
-
-
-def aws_auth():
-    """Outputs an Opensearch service client. Low level client authorizes against the boto3 session and associated AWS credentials"""
-    logger.info("Getting AWS Auth Credentials")
-    credentials = boto3.Session(region_name=REGION).get_credentials()
-    service = "es"
-    awsauth = AWS4Auth(
-        credentials.access_key,
-        credentials.secret_key,
-        REGION,
-        service,
-        session_token=credentials.token,
-    )
-    opensearch_client = OpenSearch(
-        hosts=[{"host": OPENSEARCH_URL, "port": OPENSEARCH_PORT}],
-        http_auth=awsauth,
-        use_ssl=False,
-        verify_certs=False,
-        connection_class=RequestsHttpConnection,
-    )
-
-    return opensearch_client
 
 
 @router.post("/search")

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,5 +1,7 @@
 """Utility functions"""
 
+from functools import wraps
+
 from app import config
 
 
@@ -9,3 +11,21 @@ def get_task_queue():
         return config.sqs.get_queue_by_name(QueueName=config.TASK_QUEUE_NAME)
     else:
         return config.sqs.Queue(config.TASK_QUEUE_URL)
+
+
+def run_once(f):
+    """
+    # From https://stackoverflow.com/a/4104188/3436502
+    Runs a function (successfully) only once.
+    The running can be reset by setting the `has_run` attribute to False
+    """
+
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        if not getattr(wrapper, "has_run", False):
+            result = f(*args, **kwargs)
+            setattr(wrapper, "has_run", True)
+            return result
+
+    setattr(wrapper, "has_run", False)
+    return wrapper


### PR DESCRIPTION
Related to
- https://github.com/NASA-IMPACT/nasa-apt/issues/500

## Alternative option
Run this on app startup
```diff
diff --git a/app/main.py b/app/main.py
index d341927..63f8e87 100644
--- a/app/main.py
+++ b/app/main.py
@@ -37,3 +37,15 @@ app.include_router(api_router, prefix=config.API_VERSION_STRING)
 def ping():
     """Health check."""
     return {"ping": "pong!"}
+
+
+@app.on_event("startup")
+def create_search_indices():
+    """Create index in opensearch if not exists already."""
+    from app.search.opensearch import (
+        aws_auth,
+        create_search_indices as o_create_search_indices,
+    )
+
+    opensearch_client = aws_auth()
+    o_create_search_indices(opensearch_client)
diff --git a/docker-compose.yml b/docker-compose.yml
index afcfcbf..ff0fe32 100644
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,6 +130,7 @@ services:
       PDF_PREVIEW_HOST: http://ui:9000
     depends_on:
       - bootstrapper
+      - opensearch
 
   worker:
     build:
```
Why not used in this PR: Adding this change will need opensearch to be always running in development and opensearch container is a bit heavy compared to others on resource usage.