### PR TITLE
Support moving opensearch domain into the VPC

### DIFF
--- a/stack/app.py
+++ b/stack/app.py
@@ -243,6 +243,7 @@ class nasaAPTLambdaStack(core.Stack):
             BACKEND_CORS_ORIGINS=config.BACKEND_CORS_ORIGINS,
             POSTGRES_ADMIN_CREDENTIALS_ARN=database.secret.secret_arn,
             OPENSEARCH_URL=osdomain.domain_endpoint,
+            PRIVATE_OPENSEARCH_URL=private_os_domain.domain_endpoint,
             TASK_QUEUE_URL=sqs_queue.queue_url,
             S3_BUCKET=bucket.bucket_name,
             NOTIFICATIONS_FROM=config.NOTIFICATIONS_FROM,
@@ -281,8 +282,12 @@ class nasaAPTLambdaStack(core.Stack):
         os_access_policy.add_arn_principal(f"{api_handler_lambda.function_arn}")
         os_access_policy.add_actions("es:ESHttp*")
         os_access_policy.add_resources(f"{osdomain.domain_arn}/*")
-        # # add policy to domain
-        # osdomain.add_access_policies(os_access_policy)
+
+        # assign opensearch access policy to the private open search domain
+        os_access_policy.add_resources(f"{private_os_domain.domain_arn}/*")
+
+        # grant lambda read/write for private opensearch domain
+        private_os_domain.grant_read_write(api_handler_lambda)
 
         # grant lambda read/write
         osdomain.grant_read_write(api_handler_lambda)

--- a/stack/app.py
+++ b/stack/app.py
@@ -101,7 +101,7 @@ class nasaAPTLambdaStack(core.Stack):
         os_vpc_security_group.add_ingress_rule(
             peer=lambda_security_group,
             connection=ec2.Port.tcp(9200),
-            description='Allow traffic from the Lambda Security Group on port 9200'
+            description="Allow traffic from the Lambda Security Group on port 9200",
         )
 
         rds_security_group.add_ingress_rule(
@@ -205,7 +205,7 @@ class nasaAPTLambdaStack(core.Stack):
             if config.STAGE.lower() == "prod"
             else core.RemovalPolicy.DESTROY,
         )
-    
+
         # This domain is launched within a VPC
         private_os_domain = opensearch.Domain(
             self,
@@ -229,7 +229,7 @@ class nasaAPTLambdaStack(core.Stack):
             if config.STAGE.lower() == "prod"
             else core.RemovalPolicy.DESTROY,
             vpc=config.VPC_ID,
-            security_groups=[os_vpc_security_group]
+            security_groups=[os_vpc_security_group],
         )
 
         ses_access = iam.PolicyStatement(actions=["ses:SendEmail"], resources=["*"])

--- a/stack/app.py
+++ b/stack/app.py
@@ -307,7 +307,6 @@ class nasaAPTLambdaStack(core.Stack):
         os_access_policy.add_arn_principal(f"{sqs_handler_lambda.function_arn}")
         private_os_domain.grant_read_write(sqs_handler_lambda)
 
-
         # attach the task handling lambda to the queue
         sqs_event_source = lambda_event_source.SqsEventSource(sqs_queue)
         sqs_handler_lambda.add_event_source(sqs_event_source)


### PR DESCRIPTION
Demonstrates changes that may be required in order to move an existing Opensearch domain into a VPC.
See #700 for more context. 