### PR TITLE
Grant opensearch read/write access to the worker

### DIFF
--- a/stack/app.py
+++ b/stack/app.py
@@ -291,6 +291,7 @@ class nasaAPTLambdaStack(core.Stack):
         )
         bucket.grant_read_write(sqs_handler_lambda)
         database.secret.grant_read(sqs_handler_lambda)
+        osdomain.grant_read_write(sqs_handler_lambda)
 
         # attach the task handling lambda to the queue
         sqs_event_source = lambda_event_source.SqsEventSource(sqs_queue)


### PR DESCRIPTION
The worker lambda needs access to reindex documents as implemented in https://github.com/NASA-IMPACT/nasa-apt/pull/721 