### PR TITLE
Return the uploaded PDF file when exporting a PDF ATBD

### DIFF
--- a/app/api/v2/atbds.py
+++ b/app/api/v2/atbds.py
@@ -294,6 +294,9 @@ def get_upload_url(
         ExpiresIn=3600,
     )
     presigned_url = response["url"]
+    if config.APT_DEBUG:
+        # localstack is available on localhost when running in dev mode
+        presigned_url = presigned_url.replace("localstack", "localhost")
     logger.info(f"Generated presigned URL: {presigned_url}")
     return {
         "upload_url": presigned_url,

--- a/app/api/v2/pdf.py
+++ b/app/api/v2/pdf.py
@@ -16,6 +16,7 @@ from app.pdf.error_handler import generate_html_content_for_error
 from app.pdf.generator import generate_pdf
 from app.permissions import filter_atbd_versions
 from app.schemas import users, versions
+from app.schemas.atbds import AtbdDocumentTypeEnum
 from app.users.auth import get_user
 from app.users.cognito import get_active_user_principals, update_atbd_contributor_info
 from app.utils import get_task_queue
@@ -149,7 +150,10 @@ def get_pdf(
     atbd_version: AtbdVersions
     [atbd_version] = atbd.versions
 
-    pdf_key = generate_pdf_key(atbd, minor=minor, journal=journal)
+    if atbd.document_type == AtbdDocumentTypeEnum.PDF:
+        pdf_key = atbd_version.pdf.file_path
+    else:
+        pdf_key = generate_pdf_key(atbd, minor=minor, journal=journal)
 
     logger.info(f"FETCHING FROM S3: {pdf_key}")
     try:

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -10,7 +10,6 @@ from sqlalchemy import (
     ForeignKeyConstraint,
     Integer,
     String,
-    UniqueConstraint,
     types,
 )
 from sqlalchemy.dialects import postgresql

--- a/app/schemas/uploads.py
+++ b/app/schemas/uploads.py
@@ -1,13 +1,9 @@
 """Schemas for ATBDS models"""
-import enum
-from datetime import datetime
-from typing import List, Optional
 
 from pydantic import BaseModel, validator
 
 from app import config
 from app.api.utils import s3_client
-from app.schemas import versions
 
 
 class Create(BaseModel):
@@ -45,7 +41,7 @@ class FullOutput(BaseModel):
     def sign_file_path(cls, file_path):
         """Generated signed s3 url which client needs to access the files"""
         client = s3_client()
-        return client.generate_presigned_url(
+        url = client.generate_presigned_url(
             "get_object",
             Params=dict(
                 Bucket=config.S3_BUCKET,
@@ -54,3 +50,7 @@ class FullOutput(BaseModel):
             ),
             ExpiresIn=3600,
         )
+        if config.APT_DEBUG:
+            # localstack is available on localhost when running in dev mode
+            url = url.replace("localstack", "localhost")
+        return url


### PR DESCRIPTION
Also makes sure that localhost is used as the base URL instead of localstack when running in development mode and removes some unused imports.

Fixes https://github.com/NASA-IMPACT/nasa-apt-frontend/issues/495

