### PR TITLE
Changes to CDK configs for prod deployment

### DIFF
--- a/stack/app.py
+++ b/stack/app.py
@@ -289,7 +289,6 @@ class nasaAPTLambdaStack(core.Stack):
         if concurrent:
             sqs_handler_lambda_props["reserved_concurrent_executions"] = concurrent
 
-
         sqs_handler_lambda = _lambda.Function(
             self, f"{id}-sqs-handler-lambda", **sqs_handler_lambda_props
         )

--- a/stack/app.py
+++ b/stack/app.py
@@ -126,7 +126,7 @@ class nasaAPTLambdaStack(core.Stack):
             publicly_accessible=True,
             database_name="nasadb",
             backup_retention=core.Duration.days(7),
-            deletion_protection=config.STAGE.lower() == "prod",
+            deletion_protection="prod" in config.STAGE.lower(),
             removal_policy=core.RemovalPolicy.SNAPSHOT,
         )
 
@@ -151,7 +151,7 @@ class nasaAPTLambdaStack(core.Stack):
             scope=self,
             id=f"{id}",
             removal_policy=core.RemovalPolicy.RETAIN
-            if config.STAGE.lower() == "prod"
+            if "prod" in config.STAGE.lower()
             else core.RemovalPolicy.DESTROY,
         )
         if config.S3_BUCKET:
@@ -189,7 +189,7 @@ class nasaAPTLambdaStack(core.Stack):
             ),
             automated_snapshot_start_hour=0,
             removal_policy=core.RemovalPolicy.RETAIN
-            if config.STAGE.lower() == "prod"
+            if "prod" in config.STAGE.lower()
             else core.RemovalPolicy.DESTROY,
             # logging
             # logging=opensearch.LoggingOptions(
@@ -286,6 +286,10 @@ class nasaAPTLambdaStack(core.Stack):
             security_groups=[lambda_security_group],
         )
 
+        if concurrent:
+            sqs_handler_lambda_props["reserved_concurrent_executions"] = concurrent
+
+
         sqs_handler_lambda = _lambda.Function(
             self, f"{id}-sqs-handler-lambda", **sqs_handler_lambda_props
         )
@@ -336,7 +340,7 @@ class nasaAPTLambdaStack(core.Stack):
             ),
             sign_in_case_sensitive=False,
             removal_policy=core.RemovalPolicy.RETAIN
-            if config.STAGE.lower() == "prod"
+            if "prod" in config.STAGE.lower()
             else core.RemovalPolicy.DESTROY,
         )
 

--- a/stack/config.py
+++ b/stack/config.py
@@ -36,7 +36,7 @@ MEMORY: int = 1536
 
 # stack skips setting concurrency if this value is 0
 # the stack will instead use unreserved lambda concurrency
-MAX_CONCURRENT: int = 500 if STAGE == "prod" else 0
+MAX_CONCURRENT: int = 50 if "prod" in STAGE else 0
 
 # Number of times to retry a failed task
 MAX_RETRIES: int = 1


### PR DESCRIPTION
makes sure that prod specific configs are applied irrespective of whether config.STAGE is `prod` or `prod-v2`. Thanks @leothomas for live coding this during a production deploy! 😄


