### PR TITLE
More changes to import RDS instance created outside CDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
           APT_FEATURE_JOURNAL_PDF_EXPORT_ENABLED="true"
           IMPORT_EXISTING_DATABASE="true"
           EXISTING_DATABASE_ENDPOINT="nasa-apt-api-staging-db.cb4xylogqcpx.us-east-1.rds.amazonaws.com"
-          EXISTING_DATABASE_SECRET_ARN="arn:aws:secretsmanager:us-east-1:552819999234:secret:nasa-apt-api-staging-database-secrets-VSuGfT"
+          EXISTING_DATABASE_SECRET_ARN="arn:aws:secretsmanager:us-east-1:552819999234:secret:apt-encrypted-rds-secret-yHBnPW"
           EOF
       - name: Install APT dependencies
         run: |

--- a/stack/app.py
+++ b/stack/app.py
@@ -123,48 +123,10 @@ class nasaAPTLambdaStack(Stack):
 
         # TODO: add bootstrapping lambda as a custom resource to be run by cloudformation
 
-        rds_params = dict(
-            credentials=rds.Credentials.from_generated_secret(
-                username="masteruser", secret_name=f"{id}-database-secrets"
-            ),
-            allocated_storage=10,
-            vpc=vpc,
-            security_groups=[rds_security_group],
-            engine=rds.DatabaseInstanceEngine.POSTGRES,
-            # Upgraded to t3 small RDS instance since t2 small no longer
-            # supports postgres 13+
-            instance_type=ec2.InstanceType.of(
-                ec2.InstanceClass.BURSTABLE3, ec2.InstanceSize.SMALL
-            ),
-            instance_identifier=f"{id}-db",
-            vpc_subnets=ec2.SubnetSelection(subnet_type=ec2.SubnetType.PUBLIC),
-            publicly_accessible=True,
-            database_name="nasadb",
-            backup_retention=Duration.days(7),
-            deletion_protection="prod" in config.STAGE.lower(),
-            removal_policy=RemovalPolicy.SNAPSHOT,
-        )
-
-        if config.GCC_MODE:
-            rds_params["vpc_subnets"] = ec2.SubnetSelection(
-                subnet_type=ec2.SubnetType.PRIVATE_WITH_EGRESS
-            )
-            rds_params["publicly_accessible"] = False
-
-        database = rds.DatabaseInstance(self, f"{id}-postgres-db", **rds_params)
-        CfnOutput(
-            self,
-            f"{id}-database-secret-arn",
-            value=database.secret.secret_arn,
-            description=(
-                "Arn of the SecretsManager instance holding the connection info for Postgres DB"
-            ),
-        )
-
         if config.IMPORT_EXISTING_DATABASE:
             database = rds.DatabaseInstance.from_database_instance_attributes(
                 self,
-                f"{id}-postgres-db-encrypted",
+                f"{id}-postgres-database",
                 instance_identifier=f"{id}-db",
                 instance_endpoint_address=config.EXISTING_DATABASE_ENDPOINT,
                 port=5432,
@@ -176,6 +138,44 @@ class nasaAPTLambdaStack(Stack):
                 f"{id}-database-secrets",
                 secret_complete_arn=config.EXISTING_DATABASE_SECRET_ARN,
             )
+        else:
+            rds_params = dict(
+                credentials=rds.Credentials.from_generated_secret(
+                    username="masteruser", secret_name=f"{id}-database-secrets"
+                ),
+                allocated_storage=10,
+                vpc=vpc,
+                security_groups=[rds_security_group],
+                engine=rds.DatabaseInstanceEngine.POSTGRES,
+                # Upgraded to t3 small RDS instance since t2 small no longer
+                # supports postgres 13+
+                instance_type=ec2.InstanceType.of(
+                    ec2.InstanceClass.BURSTABLE3, ec2.InstanceSize.SMALL
+                ),
+                instance_identifier=f"{id}-db",
+                vpc_subnets=ec2.SubnetSelection(subnet_type=ec2.SubnetType.PUBLIC),
+                publicly_accessible=True,
+                database_name="nasadb",
+                backup_retention=Duration.days(7),
+                deletion_protection="prod" in config.STAGE.lower(),
+                removal_policy=RemovalPolicy.SNAPSHOT,
+                storage_encrypted=True,
+            )
+            if config.GCC_MODE:
+                rds_params["vpc_subnets"] = ec2.SubnetSelection(
+                    subnet_type=ec2.SubnetType.PRIVATE_WITH_EGRESS
+                )
+                rds_params["publicly_accessible"] = False
+
+            database = rds.DatabaseInstance(self, f"{id}-postgres-database", **rds_params)
+        CfnOutput(
+            self,
+            f"{id}-database-secret-arn",
+            value=database.secret.secret_arn,
+            description=(
+                "Arn of the SecretsManager instance holding the connection info for Postgres DB"
+            ),
+        )
 
         bucket_params = dict(
             scope=self,

--- a/stack/app.py
+++ b/stack/app.py
@@ -167,7 +167,9 @@ class nasaAPTLambdaStack(Stack):
                 )
                 rds_params["publicly_accessible"] = False
 
-            database = rds.DatabaseInstance(self, f"{id}-postgres-database", **rds_params)
+            database = rds.DatabaseInstance(
+                self, f"{id}-postgres-database", **rds_params
+            )
         CfnOutput(
             self,
             f"{id}-database-secret-arn",


### PR DESCRIPTION
- had to manually create a secret and import that too
- enabled encryption at rest for new RDS instance if created by CDK

continuation of #811 #812 and #813 
