### PR TITLE
Feature/remove reviewer info

### DIFF
--- a/app/acls.py
+++ b/app/acls.py
@@ -30,7 +30,7 @@ ATBD_VERSION_ACLS: Dict = {
     ],
     "owner": [
         {"action": "view"},
-        {"action": "view_update_reviewer_info"},
+        {"action": "view_reviewer_info"},
         {"action": "delete", "conditions": {"status": ["DRAFT"]}},
         {"action": "request_closed_review", "conditions": {"status": ["DRAFT"]}},
         {
@@ -87,7 +87,7 @@ ATBD_VERSION_ACLS: Dict = {
         {"action": "comment"},
     ],
     "authors": [
-        {"action": "view_update_reviewer_info"},
+        {"action": "view_reviewer_info"},
         {"action": "join_reviewers", "deny": True},
         {"action": "view"},
         {"action": "comment"},
@@ -147,7 +147,7 @@ ATBD_VERSION_ACLS: Dict = {
         {"action": "join_reviewers"},
     ],
     "role:curator": [
-        {"action": "view_update_reviewer_info"},
+        {"action": "view_reviewer_info"},
         {"action": "receive_ownership", "deny": True},
         {"action": "join_authors", "deny": True},
         {"action": "join_reviewers", "deny": True},

--- a/app/acls.py
+++ b/app/acls.py
@@ -30,7 +30,6 @@ ATBD_VERSION_ACLS: Dict = {
     ],
     "owner": [
         {"action": "view"},
-        {"action": "view_reviewer_info"},
         {"action": "delete", "conditions": {"status": ["DRAFT"]}},
         {"action": "request_closed_review", "conditions": {"status": ["DRAFT"]}},
         {
@@ -87,7 +86,6 @@ ATBD_VERSION_ACLS: Dict = {
         {"action": "comment"},
     ],
     "authors": [
-        {"action": "view_reviewer_info"},
         {"action": "join_reviewers", "deny": True},
         {"action": "view"},
         {"action": "comment"},
@@ -147,7 +145,6 @@ ATBD_VERSION_ACLS: Dict = {
         {"action": "join_reviewers"},
     ],
     "role:curator": [
-        {"action": "view_reviewer_info"},
         {"action": "receive_ownership", "deny": True},
         {"action": "join_authors", "deny": True},
         {"action": "join_reviewers", "deny": True},

--- a/app/acls.py
+++ b/app/acls.py
@@ -30,6 +30,7 @@ ATBD_VERSION_ACLS: Dict = {
     ],
     "owner": [
         {"action": "view"},
+        {"action": "view_update_reviewer_info"},
         {"action": "delete", "conditions": {"status": ["DRAFT"]}},
         {"action": "request_closed_review", "conditions": {"status": ["DRAFT"]}},
         {
@@ -86,6 +87,7 @@ ATBD_VERSION_ACLS: Dict = {
         {"action": "comment"},
     ],
     "authors": [
+        {"action": "view_update_reviewer_info"},
         {"action": "join_reviewers", "deny": True},
         {"action": "view"},
         {"action": "comment"},
@@ -145,6 +147,7 @@ ATBD_VERSION_ACLS: Dict = {
         {"action": "join_reviewers"},
     ],
     "role:curator": [
+        {"action": "view_update_reviewer_info"},
         {"action": "receive_ownership", "deny": True},
         {"action": "join_authors", "deny": True},
         {"action": "join_reviewers", "deny": True},

--- a/app/acls.py
+++ b/app/acls.py
@@ -30,7 +30,6 @@ ATBD_VERSION_ACLS: Dict = {
     ],
     "owner": [
         {"action": "view"},
-        {"action": "view_update_reviewer_info"},
         {"action": "delete", "conditions": {"status": ["DRAFT"]}},
         {"action": "request_closed_review", "conditions": {"status": ["DRAFT"]}},
         {
@@ -87,7 +86,6 @@ ATBD_VERSION_ACLS: Dict = {
         {"action": "comment"},
     ],
     "authors": [
-        {"action": "view_update_reviewer_info"},
         {"action": "join_reviewers", "deny": True},
         {"action": "view"},
         {"action": "comment"},
@@ -147,7 +145,6 @@ ATBD_VERSION_ACLS: Dict = {
         {"action": "join_reviewers"},
     ],
     "role:curator": [
-        {"action": "view_update_reviewer_info"},
         {"action": "receive_ownership", "deny": True},
         {"action": "join_authors", "deny": True},
         {"action": "join_reviewers", "deny": True},

--- a/app/api/v2/versions.py
+++ b/app/api/v2/versions.py
@@ -72,18 +72,6 @@ def get_version(
     atbd = crud_atbds.get(db=db, atbd_id=atbd_id, version=major)
     [atbd_version] = atbd.versions
     check_permissions(principals=principals, action="view", acl=atbd_version.__acl__())
-    # Hide reviewer info from atbd_version for other users
-    if not check_permissions(
-        principals=principals,
-        action="view_reviewer_info",
-        acl=atbd_version.__acl__(),
-        raise_exception=False,
-    ):
-        atbd_version.contacts_link = [
-            contact_link
-            for contact_link in atbd_version.contacts_link or []
-            if RolesEnum.DOCUMENT_REVIEWER.value not in contact_link.roles or []
-        ]
     atbd = update_atbd_contributor_info(principals, atbd)
     return atbd
 

--- a/app/api/v2/versions.py
+++ b/app/api/v2/versions.py
@@ -75,7 +75,7 @@ def get_version(
     # Hide reviewer info from atbd_version for other users
     if not check_permissions(
         principals=principals,
-        action="view_update_reviewer_info",
+        action="view_reviewer_info",
         acl=atbd_version.__acl__(),
         raise_exception=False,
     ):
@@ -184,14 +184,10 @@ def update_atbd_version(  # noqa : C901
 
     if version_input.contacts is not None:
 
-        contact_has_reviewer_info = False
         # Overwrite any existing `ContactAssociation` items
         # in the database - this makes updating roles on an existing
         # contacts_link item possible.
         for contact in version_input.contacts:
-            if RolesEnum.DOCUMENT_REVIEWER.value in (contact.roles or []):
-                contact_has_reviewer_info = True
-
             crud_contacts_associations.upsert(
                 db_session=db,
                 obj_in=versions_contacts.ContactsAssociation(
@@ -201,14 +197,6 @@ def update_atbd_version(  # noqa : C901
                     roles=contact.roles,
                     affiliations=contact.affiliations,
                 ),
-            )
-
-        # Check if user have permission to do this
-        if contact_has_reviewer_info:
-            check_permissions(
-                principals=principals,
-                action="view_update_reviewer_info",
-                acl=atbd_version.__acl__(),
             )
 
         # Remove contacts not in the input data contacts

--- a/app/api/v2/versions.py
+++ b/app/api/v2/versions.py
@@ -71,14 +71,6 @@ def get_version(
     atbd = crud_atbds.get(db=db, atbd_id=atbd_id, version=major)
     [atbd_version] = atbd.versions
     check_permissions(principals=principals, action="view", acl=atbd_version.__acl__())
-    # Hide reviewer_info from atbd_version for other users
-    if not check_permissions(
-        principals=principals,
-        action="view_update_reviewer_info",
-        acl=atbd_version.__acl__(),
-        raise_exception=False,
-    ):
-        del atbd_version.reviewer_info
     atbd = update_atbd_contributor_info(principals, atbd)
     return atbd
 
@@ -261,14 +253,6 @@ def update_atbd_version(  # noqa : C901
     # # This should act on the update input object, and not the db object
     # atbd_version.last_updated_by = user.sub
     # atbd_version.last_updated_at = datetime.datetime.now(datetime.timezone.utc)
-
-    # Hide reviewer_info from atbd_version for other users
-    if version_input.reviewer_info:
-        check_permissions(
-            principals=principals,
-            action="view_update_reviewer_info",
-            acl=atbd_version.__acl__(),
-        )
 
     crud_versions.update(
         db=db,

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -97,7 +97,6 @@ class AtbdVersions(Base):
     journal_status = Column(String())
     keywords = Column(postgresql.ARRAY(postgresql.JSONB), server_default="{{}}")
     locked_by = Column(String(), nullable=True)
-    reviewer_info = Column(postgresql.JSONB, server_default="{{}}")
 
     pdf = relationship(
         "PDFUpload",

--- a/app/schemas/versions.py
+++ b/app/schemas/versions.py
@@ -103,17 +103,6 @@ class PublicationUnits(BaseModel):
         )
 
 
-class ReviewerInfo(BaseModel):
-    """
-    Information about reviewer provided by Authors which is used by curator to get contact with respective reviewers
-    """
-
-    first_name: Optional[str]
-    last_name: Optional[str]
-    email: Optional[str]
-    affiliations: Optional[List[str]] = []
-
-
 class Keyword(BaseModel):
     """GCMD KMS keyword API output to store in DB"""
 
@@ -166,7 +155,6 @@ class FullOutput(AtbdVersionSummaryOutput):
     doi: Optional[str]
     contacts_link: Optional[List[versions_contacts.ContactsLinkOutput]]
     publication_units: Optional[PublicationUnits]
-    reviewer_info: Optional[ReviewerInfo]
 
     @validator("publication_units", always=True)
     def _generate_publication_units(cls, v, values: Dict[str, Any]) -> PublicationUnits:
@@ -338,7 +326,6 @@ class Update(BaseModel):
     authors: Optional[List[str]]
     reviewers: Optional[List[str]]
     journal_status: Optional[JournalStatusEnum]
-    reviewer_info: Optional[ReviewerInfo]
 
 
 class AdminUpdate(Update):

--- a/app/schemas/versions_contacts.py
+++ b/app/schemas/versions_contacts.py
@@ -44,6 +44,7 @@ class RolesEnum(str, Enum):
     INVESTIGATION = "Investigation"
     FUNDING_ACQUISITION = "Funding acquisition"
     CORRESPONDING_AUTHOR = "Corresponding Author"
+    DOCUMENT_REVIEWER = "Document Reviewer"
 
 
 class AtbdLinkOutput(BaseModel):

--- a/db/deploy/remove_reviewer_info_in_atbd_version.sql
+++ b/db/deploy/remove_reviewer_info_in_atbd_version.sql
@@ -1,0 +1,10 @@
+-- Deploy nasa-apt:remove_reviewer_info_in_atbd_version to pg
+-- requires: add_reviewer_info_in_atbd_version
+
+BEGIN;
+
+-- NOTE: This will cause data loss
+ALTER TABLE apt.atbd_versions
+    DROP COLUMN "reviewer_info";
+
+COMMIT;

--- a/db/revert/remove_reviewer_info_in_atbd_version.sql
+++ b/db/revert/remove_reviewer_info_in_atbd_version.sql
@@ -1,0 +1,8 @@
+-- Revert nasa-apt:remove_reviewer_info_in_atbd_version from pg
+
+BEGIN;
+
+ALTER TABLE apt.atbd_versions
+    ADD COLUMN "reviewer_info" json DEFAULT '{}';
+
+COMMIT;

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -29,3 +29,4 @@ threads_notify [threads] 2022-07-27T07:06:50Z Oliver Roick <oroick@192-168-1-106
 add_pdf_uploads_table [tables] 2023-05-22T05:40:55Z navin <navin@nav-machine> # Add PDF upload Table
 add_pdf_in_atbd [add_pdf_uploads_table] 2023-05-22T06:06:10Z navin <navin@nav-machine> # Add PDF upload support to ATBD
 add_reviewer_info_in_atbd_version 2023-08-03T07:07:52Z navin <navin@nav-machine> # Add Reviewer info column ATBD Version
+remove_reviewer_info_in_atbd_version 2023-10-11T08:05:21Z navin <navin@nav-machine> # Remove Reviewer info column ATBD Version

--- a/db/verify/remove_reviewer_info_in_atbd_version.sql
+++ b/db/verify/remove_reviewer_info_in_atbd_version.sql
@@ -1,0 +1,7 @@
+-- Verify nasa-apt:remove_reviewer_info_in_atbd_version on pg
+
+BEGIN;
+
+-- XXX Add verifications here.
+
+ROLLBACK;


### PR DESCRIPTION
Related to:
- https://github.com/NASA-IMPACT/nasa-apt/issues/753#issuecomment-1755786284

Changes
- Remove recently added review_info from ATBD versions (Revert of https://github.com/NASA-IMPACT/nasa-apt/pull/783)
- Add `Document Reviewer` as contact role enum
   - NOTE: Enum are stored as string in the database
     - https://github.com/NASA-IMPACT/nasa-apt/commit/889d6c77
     - https://github.com/NASA-IMPACT/nasa-apt/pull/417